### PR TITLE
Fix task import failing for single objects and losing version history

### DIFF
--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -119,7 +119,17 @@ export function useTasks(
         try {
             const text = await file.text();
             const parsed = JSON.parse(text);
-            const list = Array.isArray(parsed) ? parsed : parsed?.tasks;
+            let list;
+            if (Array.isArray(parsed)) {
+                list = parsed;
+            } else if (parsed && typeof parsed === 'object') {
+                if (Array.isArray(parsed.tasks)) {
+                    list = parsed.tasks;
+                } else if (parsed.id || parsed.url || parsed.mode) {
+                    list = [parsed];
+                }
+            }
+
             if (!Array.isArray(list)) {
                 showAlert('Invalid import file.', 'error');
                 return;

--- a/src/server/routes/tasks.js
+++ b/src/server/routes/tasks.js
@@ -30,15 +30,13 @@ router.post('/', requireAuth, async (req, res) => {
         if (index > -1) {
             if (req.query.version === 'true') {
                 appendTaskVersion(tasks[index]);
+                newTask.versions = tasks[index].versions;
+            } else {
+                newTask.versions = Array.isArray(newTask.versions) ? newTask.versions : (tasks[index].versions || []);
             }
-            // Preserve versions if not creating a new one, as the client might not send them back full
-            // Actually client typically sends full task. But if not, we should be careful.
-            // existing implementation: newTask.versions = tasks[index].versions || [];
-            // We should ensure versions are preserved.
-            newTask.versions = tasks[index].versions || [];
             tasks[index] = newTask;
         } else {
-            newTask.versions = [];
+            newTask.versions = Array.isArray(newTask.versions) ? newTask.versions : [];
             tasks.push(newTask);
         }
 

--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -71,7 +71,6 @@ export const normalizeImportedTask = (raw: any, index: number): Task | null => {
     merged.disableRecording = parseBooleanFlag(merged.disableRecording);
     if (merged.statelessExecution === undefined) merged.statelessExecution = false;
     merged.statelessExecution = parseBooleanFlag(merged.statelessExecution);
-    delete merged.versions;
     delete merged.last_opened;
     return merged;
 };


### PR DESCRIPTION
This change fixes an issue where importing a task JSON file containing version history would result in the loss of that history. 

Changes:
- `src/hooks/useTasks.ts`: `importTasks` now detects and wraps single task objects into an array before processing.
- `src/utils/taskUtils.ts`: `normalizeImportedTask` no longer deletes the `versions` property.
- `src/server/routes/tasks.js`: The `POST /` route now uses the `versions` array from the request body if it is provided, instead of always overwriting it with the server's existing version history or an empty array. This allows imports to correctly populate task history.


---
*PR created automatically by Jules for task [1329977516508471503](https://jules.google.com/task/1329977516508471503) started by @asernasr*