### PR TITLE
🧹 server: remove unused taskMutex import

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,6 @@ const {
 
 // Context & Utils
 const {
-    taskMutex,
     executionStreams,
     stopRequests,
     sendExecutionUpdate


### PR DESCRIPTION
Removed unused `taskMutex` import from `server.js` as it was not being used in that file. This improves code health and maintainability. Verified that the server starts correctly and no functionality is affected. Ensure no changes to `package-lock.json` are included.

---
*PR created automatically by Jules for task [14313777445084434474](https://jules.google.com/task/14313777445084434474) started by @asernasr*