### PR TITLE
feat(agent): support {$html} and reserved html variable

### DIFF
--- a/src/agent/action-handler.js
+++ b/src/agent/action-handler.js
@@ -297,6 +297,7 @@ const executeAction = async (act, context) => {
             logs.push('Running custom JavaScript...');
             if (act.value) {
                 result = await page.evaluate((code) => {
+                    const html = document.documentElement.outerHTML;
                     // eslint-disable-next-line no-eval
                     return eval(code);
                 }, resolveMaybe(act.value));

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -218,6 +218,14 @@ async function handleAgent(req, res) {
             const act = actions[index];
             actionIdx += 1;
 
+            if (JSON.stringify(act).includes('{$html}')) {
+                try {
+                    runtimeVars.html = await page.content();
+                } catch (err) {
+                    runtimeVars.html = '';
+                }
+            }
+
             if (act.disabled) {
                 logs.push(`SKIPPED disabled action: ${act.type}`);
                 reportProgress(runId, { actionId: act.id, status: 'skipped' });
@@ -451,6 +459,15 @@ async function handleAgent(req, res) {
         const extractionScriptRaw = typeof data.extractionScript === 'string'
             ? data.extractionScript
             : (data.taskSnapshot && typeof data.taskSnapshot.extractionScript === 'string' ? data.taskSnapshot.extractionScript : undefined);
+
+        if (extractionScriptRaw && extractionScriptRaw.includes('{$html}')) {
+            try {
+                runtimeVars.html = await page.content();
+            } catch (err) {
+                runtimeVars.html = '';
+            }
+        }
+
         const extractionScript = extractionScriptRaw ? resolveTemplate(extractionScriptRaw) : undefined;
         const extraction = await runExtractionScript(extractionScript, cleanedHtml, page.url(), includeShadowDom);
 

--- a/src/agent/logic-handler.js
+++ b/src/agent/logic-handler.js
@@ -93,10 +93,11 @@ const evalCondition = async (expr, page, runtimeVars, lastBlockOutput, resolveTe
             return el ? (el.textContent || '').trim() : '';
         };
         const url = () => window.location.href;
+        const html = document.documentElement.outerHTML;
         const block = { output: blockOutput };
         // eslint-disable-next-line no-new-func
-        const fn = new Function('vars', 'block', 'exists', 'text', 'url', `return !!(${expression});`);
-        return fn(vars || {}, block, exists, text, url);
+        const fn = new Function('vars', 'block', 'exists', 'text', 'url', 'html', `return !!(${expression});`);
+        return fn(vars || {}, block, exists, text, url, html);
     }, { expression: resolved, vars: runtimeVars, blockOutput: lastBlockOutput });
 };
 


### PR DESCRIPTION
This PR introduces `{$html}` and `html` as reserved variables in the agent execution context. 

- `{$html}` resolves to the full HTML content (via `page.content()`) when used in action strings or extraction scripts.
- The variable `html` is injected into the JavaScript execution scope for `if`/`while` conditions and `javascript` actions, providing direct access to `document.documentElement.outerHTML`.

This simplifies tasks that require inspecting or logging the page content.

---
*PR created automatically by Jules for task [16591120578119260335](https://jules.google.com/task/16591120578119260335) started by @asernasr*