### PR TITLE
Add loading spinner to AuthScreen submit button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-02-13 - Context-Dependent Input Accessibility
 **Learning:** Edit modes that replace text with inputs often drop context (labels/placeholders), relying on the user's memory of the original text's meaning.
 **Action:** Always ensure inputs in edit modes retain the context via placeholders and aria-labels, mirroring the read-only state's semantics.
+
+## 2025-05-20 - Loading State Feedback
+**Learning:** Async buttons (like Auth submit) often rely on text changes ("Authenticating...") which can be missed. A visual spinner provides immediate, universal feedback.
+**Action:** When adding async actions, always pair the disabled state with a visual indicator (spinner) inside the button.

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -99,8 +99,11 @@ const AuthScreen: React.FC<AuthScreenProps> = ({ status, onSubmit, error, busy =
                         type="submit"
                         disabled={busy}
                         aria-busy={busy}
-                        className="shine-effect w-full bg-white text-black py-4 rounded-2xl font-bold text-[10px] tracking-[0.3em] uppercase hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-60 disabled:cursor-default"
+                        className="shine-effect w-full bg-white text-black py-4 rounded-2xl font-bold text-[10px] tracking-[0.3em] uppercase hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-60 disabled:cursor-default flex items-center justify-center gap-3"
                     >
+                        {busy && (
+                            <div className="w-4 h-4 border-2 border-black/10 border-t-black rounded-full animate-spin" />
+                        )}
                         {buttonLabel}
                     </button>
 


### PR DESCRIPTION
**Problem:**
The authentication submit button only changed text (e.g., "Authenticating...") during async operations, which can be subtle and missed by users expecting a visual indicator of activity.

**Solution:**
I added a loading spinner inside the submit button on `AuthScreen.tsx`. The spinner appears conditionally when the `busy` prop is true. I also updated the button's layout using Flexbox to center the text and spinner with a gap.

**Changes:**
- Modified `src/components/AuthScreen.tsx`:
    - Added `flex items-center justify-center gap-3` to the button className.
    - Added conditional rendering for the spinner: `<div className="w-4 h-4 border-2 border-black/10 border-t-black rounded-full animate-spin" />`.
- Updated `.Jules/palette.md` with a learning about using visual indicators for async actions.

**Verification:**
- **Build:** `npm run build` passed successfully.
- **Visual:** Verified using a Playwright script that intercepts the login request and delays the response, confirming the spinner appears and is aligned correctly next to the text while the button is disabled. Screenshot confirmed the visual implementation.

---
*PR created automatically by Jules for task [7444319823676776778](https://jules.google.com/task/7444319823676776778) started by @asernasr*