### PR TITLE
Add 'Wait for Selector' block

### DIFF
--- a/backend.log
+++ b/backend.log
@@ -1,1 +1,0 @@
-Server running at http://localhost:11345

--- a/src/agent/action-handler.js
+++ b/src/agent/action-handler.js
@@ -231,6 +231,18 @@ const executeAction = async (act, context) => {
             }
             result = ms;
             break;
+        case 'wait_selector': {
+            const selector = resolveMaybe(act.selector);
+            const ms = act.value ? parseFloat(resolveMaybe(act.value)) * 1000 : 10000;
+            logs.push(`Waiting for selector: ${selector} (${ms}ms)`);
+            if (selector) {
+                await page.waitForSelector(selector, { timeout: ms, state: 'visible' });
+                result = true;
+            } else {
+                logs.push('No selector provided for wait_selector');
+            }
+            break;
+        }
         case 'select':
             logs.push(`Selecting ${resolveMaybe(act.value)} from ${resolveMaybe(act.selector)}`);
             await page.waitForSelector(resolveMaybe(act.selector), { timeout: actionTimeout });

--- a/src/components/EditorScreen.tsx
+++ b/src/components/EditorScreen.tsx
@@ -816,6 +816,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                                     if (type === 'hover') return <Target className={`${iconClass} text-purple-300`} />;
                                                     if (type === 'press') return <Keyboard className={`${iconClass} text-amber-300`} />;
                                                     if (type === 'wait') return <Clock className={`${iconClass} text-slate-300`} />;
+                                                    if (type === 'wait_selector') return <Clock className={`${iconClass} text-orange-300`} />;
                                                     if (type === 'scroll') return <ArrowDownUp className={`${iconClass} text-cyan-300`} />;
                                                     if (type === 'javascript') return <Code className={`${iconClass} text-yellow-300`} />;
                                                     if (type === 'csv') return <Table className={`${iconClass} text-emerald-300`} />;
@@ -888,7 +889,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                                                 <X className="w-4 h-4" />
                                                             </button>
                                                         </div>
-                                                        {(action.type === 'click' || action.type === 'type' || action.type === 'hover') && (
+                                                        {(action.type === 'click' || action.type === 'type' || action.type === 'hover' || action.type === 'wait_selector') && (
                                                             <div className="space-y-1.5">
                                                                 <label className="text-[7px] font-bold text-gray-600 uppercase tracking-widest pl-1">Selector</label>
                                                                 <div className="bg-white/[0.03] border border-white/5 rounded-xl px-3 py-2 text-[11px] focus-within:border-white/20 transition-all">
@@ -932,7 +933,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                                             </div>
                                                         )}
 
-                                                        {(action.type === 'navigate' || action.type === 'type' || action.type === 'wait' || action.type === 'scroll' || action.type === 'javascript' || action.type === 'csv') && (
+                                                        {(action.type === 'navigate' || action.type === 'type' || action.type === 'wait' || action.type === 'wait_selector' || action.type === 'scroll' || action.type === 'javascript' || action.type === 'csv') && (
                                                             <div className="space-y-1.5">
                                                                 <label className="text-[7px] font-bold text-gray-600 uppercase tracking-widest pl-1">
                                                                     {action.type === 'navigate'
@@ -941,11 +942,13 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                                                             ? 'Content'
                                                                             : action.type === 'wait'
                                                                                 ? 'Seconds'
-                                                                                : action.type === 'scroll'
-                                                                                    ? 'Pixels'
-                                                                                    : action.type === 'csv'
-                                                                                        ? 'CSV Input'
-                                                                                        : 'Script'}
+                                                                                : action.type === 'wait_selector'
+                                                                                    ? 'Timeout (Sec)'
+                                                                                    : action.type === 'scroll'
+                                                                                        ? 'Pixels'
+                                                                                        : action.type === 'csv'
+                                                                                            ? 'CSV Input'
+                                                                                            : 'Script'}
                                                                 </label>
                                                                 <div className="bg-white/[0.03] border border-white/5 rounded-xl px-3 py-2 text-[11px] focus-within:border-white/20 transition-all">
                                                                     {action.type === 'javascript' ? (
@@ -974,7 +977,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                                                             onChange={(v) => updateAction(action.id, { value: v })}
                                                                             onBlur={() => handleAutoSave()}
                                                                             variables={currentTask.variables}
-                                                                            placeholder={action.type === 'navigate' ? 'https://example.com' : action.type === 'type' ? 'Search keywords' : action.type === 'wait' ? '3' : '400'}
+                                                                            placeholder={action.type === 'navigate' ? 'https://example.com' : action.type === 'type' ? 'Search keywords' : action.type === 'wait' ? '3' : action.type === 'wait_selector' ? '10' : '400'}
                                                                         />
                                                                     )}
                                                                 </div>

--- a/src/components/editor/actionCatalog.ts
+++ b/src/components/editor/actionCatalog.ts
@@ -6,6 +6,7 @@ export const ACTION_CATALOG: { type: Action['type']; label: string; description:
     { type: 'hover', label: 'Hover', description: 'Hover an element' },
     { type: 'press', label: 'Press', description: 'Press a key' },
     { type: 'wait', label: 'Wait', description: 'Pause for seconds' },
+    { type: 'wait_selector', label: 'Wait for Selector', description: 'Wait until element appears' },
     { type: 'scroll', label: 'Scroll', description: 'Scroll the page or container' },
     { type: 'javascript', label: 'JavaScript', description: 'Run custom JS' },
     { type: 'csv', label: 'CSV', description: 'Parse CSV into rows' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface Action {
     | 'click'
     | 'type'
     | 'wait'
+    | 'wait_selector'
     | 'press'
     | 'scroll'
     | 'javascript'

--- a/tests/test_wait_selector.js
+++ b/tests/test_wait_selector.js
@@ -1,0 +1,91 @@
+
+const http = require('http');
+const { chromium } = require('playwright');
+const { executeAction } = require('../src/agent/action-handler');
+
+const PORT = 3000;
+const BASE_URL = `http://localhost:${PORT}`;
+
+const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`
+        <html>
+            <body>
+                <h1>Wait Selector Test</h1>
+                <script>
+                    setTimeout(() => {
+                        const div = document.createElement('div');
+                        div.id = 'target';
+                        div.textContent = 'I appeared!';
+                        document.body.appendChild(div);
+                    }, 2000);
+                </script>
+            </body>
+        </html>
+    `);
+});
+
+async function runTest() {
+    let browser;
+    try {
+        await new Promise(resolve => server.listen(PORT, resolve));
+        console.log(`Server started on ${BASE_URL}`);
+
+        browser = await chromium.launch({ headless: true });
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.goto(BASE_URL);
+
+        const logs = [];
+        const mockContext = {
+            page,
+            logs,
+            runtimeVars: {},
+            resolveTemplate: (str) => str,
+            options: {},
+            baseDelay: () => 0
+        };
+
+        // Test 1: Wait for existing/future element
+        console.log('Test 1: Waiting for #target...');
+        const startTime = Date.now();
+        await executeAction({
+            type: 'wait_selector',
+            selector: '#target',
+            value: '5' // 5 seconds timeout
+        }, mockContext);
+        const duration = Date.now() - startTime;
+
+        console.log(`Test 1 completed in ${duration}ms`);
+        if (duration < 2000) {
+            throw new Error('Test 1 failed: Waited less than 2 seconds, meaning it didn\'t wait for the element.');
+        }
+
+        // Test 2: Timeout
+        console.log('Test 2: Waiting for non-existent element (should fail)...');
+        try {
+            await executeAction({
+                type: 'wait_selector',
+                selector: '#nonexistent',
+                value: '1' // 1 second timeout
+            }, mockContext);
+            throw new Error('Test 2 failed: Did not throw on timeout.');
+        } catch (e) {
+            if (e.message.includes('Timeout') || e.name === 'TimeoutError') {
+                console.log('Test 2 passed: Caught expected timeout.');
+            } else {
+                throw e;
+            }
+        }
+
+        console.log('All tests passed!');
+    } catch (error) {
+        console.error('Test failed:', error);
+        process.exit(1);
+    } finally {
+        if (browser) await browser.close();
+        server.close();
+    }
+}
+
+runTest();


### PR DESCRIPTION
Implemented a new 'Wait for Selector' block in the visual editor and agent. Users can now add a block that waits for a specific CSS selector to appear on the page before proceeding, with a configurable timeout. This is useful for handling dynamic content loading. Verified with backend integration tests and frontend visual verification.

---
*PR created automatically by Jules for task [3576148792221778710](https://jules.google.com/task/3576148792221778710) started by @asernasr*