### PR TITLE
🛡️ Sentinel: Fix SSRF bypass via 0.0.0.0

### DIFF
--- a/tests/url-utils.test.js
+++ b/tests/url-utils.test.js
@@ -10,6 +10,7 @@ const ipv4Cases = [
     { ip: '172.31.255.255', expected: true },
     { ip: '192.168.1.1', expected: true },
     { ip: '169.254.1.1', expected: true },
+    { ip: '0.0.0.0', expected: true },
     { ip: '8.8.8.8', expected: false },
     { ip: '1.1.1.1', expected: false },
     { ip: '172.32.0.1', expected: false },
@@ -50,6 +51,7 @@ async function testValidateUrl() {
         { url: 'http://[fe80::1]', expectedBlock: true },
         { url: 'http://[::]', expectedBlock: true },
         { url: 'http://[::ffff:127.0.0.1]', expectedBlock: true },
+        { url: 'http://0.0.0.0', expectedBlock: true },
         { url: 'https://www.google.com', expectedBlock: false },
     ];
 

--- a/url-utils.js
+++ b/url-utils.js
@@ -11,6 +11,7 @@ function isPrivateIP(ip) {
     if (net.isIPv4(ip)) {
         const parts = ip.split('.').map(Number);
         return (
+            parts[0] === 0 ||
             parts[0] === 10 ||
             (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
             (parts[0] === 192 && parts[1] === 168) ||


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF bypass via 0.0.0.0

🚨 Severity: HIGH
💡 Vulnerability: SSRF bypass using `0.0.0.0` or `0` which resolves to localhost on some systems but was not caught by `isPrivateIP`.
🎯 Impact: Attackers could access internal services running on localhost even if `ALLOW_PRIVATE_NETWORKS` was set to false.
🔧 Fix: Updated `isPrivateIP` in `url-utils.js` to block `0.0.0.0/8` range.
✅ Verification: Added test cases to `tests/url-utils.test.js` covering `0.0.0.0` IP and URL. Verified `ALLOW_PRIVATE_NETWORKS=false node tests/url-utils.test.js` passes.

---
*PR created automatically by Jules for task [16524160066636085063](https://jules.google.com/task/16524160066636085063) started by @asernasr*