### PR TITLE
🎨 Palette: Add loading state and icon to Captures refresh button

### DIFF
--- a/src/components/CapturesScreen.tsx
+++ b/src/components/CapturesScreen.tsx
@@ -3,6 +3,7 @@ import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { useNavigate } from 'react-router-dom';
 import { ConfirmRequest, CaptureEntry } from '../types';
 import CaptureCard from './CaptureCard';
+import MaterialIcon from './MaterialIcon';
 
 interface CapturesScreenProps {
     onConfirm: (request: string | ConfirmRequest) => Promise<boolean>;
@@ -84,8 +85,11 @@ const CapturesScreen: React.FC<CapturesScreenProps> = ({ onConfirm, onNotify }) 
                     <div className="flex items-center gap-2">
                         <button
                             onClick={loadCaptures}
-                            className="px-4 py-2 text-[9px] font-bold uppercase tracking-widest rounded-xl bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all"
+                            disabled={loading}
+                            aria-busy={loading}
+                            className="px-4 py-2 text-[9px] font-bold uppercase tracking-widest rounded-xl bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all disabled:opacity-50 inline-flex items-center gap-2"
                         >
+                            <MaterialIcon name="sync" className={`text-base ${loading ? 'animate-spin' : ''}`} />
                             Refresh
                         </button>
                         <button


### PR DESCRIPTION
This PR enhances the UX of the "Refresh" button on the Captures screen by adding a loading spinner and proper accessibility attributes. Previously, the button was text-only and provided no visual feedback during data fetching. Now, it displays a spinning sync icon when loading and becomes disabled to prevent multiple clicks, aligning with the behavior seen in the Proxies panel.
Wait, I should confirm the title format. "feat(ui): ..." is standard conventional commits.
Also include:
💡 What: Added loading spinner and icon to Captures refresh button.
🎯 Why: To provide visual feedback during data fetching and improve accessibility.
📸 Before/After: (Cannot include screenshots here directly but described in description)
♿ Accessibility: Added `aria-busy` and disabled state.

---
*PR created automatically by Jules for task [14979366101122319503](https://jules.google.com/task/14979366101122319503) started by @asernasr*