### PR TITLE
Improve SSRF protection with CGNAT detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 |----------|---------|---------|
 | `SESSION_SECRET` | Signs session cookies. Required. | — |
 | `ALLOWED_IPS` | Comma list for basic IP allowlisting. | none (open) |
+| `ALLOW_PRIVATE_NETWORKS` | Allow scraping local/private IPs (SSRF risk). | `true` |
 | `TRUST_PROXY` | Honor `X-Forwarded-*` when behind a reverse proxy. | `0` |
 | `VITE_DEV_PORT` | Port for front-end dev server. | `5173` |
 | `VITE_BACKEND_PORT` | Backend port for proxying + scripts. | `11345` |

--- a/tests/url-utils.test.js
+++ b/tests/url-utils.test.js
@@ -1,4 +1,8 @@
 const assert = require('assert');
+
+// Enforce blocking for tests
+process.env.ALLOW_PRIVATE_NETWORKS = 'false';
+
 const { isPrivateIP, validateUrl } = require('../url-utils');
 
 console.log('Testing isPrivateIP...');
@@ -11,9 +15,12 @@ const ipv4Cases = [
     { ip: '192.168.1.1', expected: true },
     { ip: '169.254.1.1', expected: true },
     { ip: '0.0.0.0', expected: true },
+    { ip: '100.64.0.1', expected: true },
+    { ip: '100.127.255.255', expected: true },
     { ip: '8.8.8.8', expected: false },
     { ip: '1.1.1.1', expected: false },
     { ip: '172.32.0.1', expected: false },
+    { ip: '100.128.0.1', expected: false },
 ];
 
 for (const { ip, expected } of ipv4Cases) {

--- a/tests/verify_ssrf_fix.js
+++ b/tests/verify_ssrf_fix.js
@@ -1,3 +1,6 @@
+// Enforce blocking for tests
+process.env.ALLOW_PRIVATE_NETWORKS = 'false';
+
 const { validateUrl } = require('../url-utils');
 
 async function testValidateUrl() {

--- a/url-utils.js
+++ b/url-utils.js
@@ -13,6 +13,7 @@ function isPrivateIP(ip) {
         return (
             parts[0] === 0 ||
             parts[0] === 10 ||
+            (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) ||
             (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
             (parts[0] === 192 && parts[1] === 168) ||
             parts[0] === 127 ||


### PR DESCRIPTION
This change improves the Server-Side Request Forgery (SSRF) protection mechanism by adding the Carrier-Grade NAT (CGNAT) IP range (`100.64.0.0/10`) to the `isPrivateIP` check. While `ALLOW_PRIVATE_NETWORKS` defaults to `true` (allowing access to private networks by default, as requested), this fix ensures that when the protection *is* enabled (by setting the environment variable to `false`), it correctly identifies and blocks CGNAT addresses, which are often used in internal cloud environments.

This change also updates the documentation to reflect the default behavior and ensures tests run with the protection enabled to verify the logic.

---
*PR created automatically by Jules for task [16434015379097231309](https://jules.google.com/task/16434015379097231309) started by @asernasr*