### PR TITLE
🎨 Palette: Use reusable CopyButton in API Key settings

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -9,6 +9,7 @@ interface CopyButtonProps {
   iconClassName?: string;
   onCopy?: () => void;
   title?: string;
+  disabled?: boolean;
 }
 
 const CopyButton: React.FC<CopyButtonProps> = ({
@@ -18,11 +19,13 @@ const CopyButton: React.FC<CopyButtonProps> = ({
   iconClassName,
   onCopy,
   title,
+  disabled = false,
 }) => {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (disabled) return;
     const success = await copyToClipboard(text);
     if (success) {
       setCopied(true);
@@ -34,17 +37,25 @@ const CopyButton: React.FC<CopyButtonProps> = ({
   return (
     <button
       onClick={handleCopy}
+      disabled={disabled}
       className={
         className ||
-        "flex items-center gap-2 px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all text-[9px] font-bold uppercase tracking-widest"
+        "flex items-center gap-2 px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all text-[9px] font-bold uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed"
       }
       title={title || (copied ? "Copied" : "Copy")}
       type="button"
+      aria-label={label || title || "Copy to clipboard"}
     >
       {copied ? (
-        <MaterialIcon name="check" className={iconClassName || "text-sm text-green-400"} />
+        <MaterialIcon
+          name="check"
+          className={`${iconClassName || "text-sm"} text-green-400`}
+        />
       ) : (
-        <MaterialIcon name="content_copy" className={iconClassName || "text-sm"} />
+        <MaterialIcon
+          name="content_copy"
+          className={iconClassName || "text-sm"}
+        />
       )}
       {label && <span>{copied ? "Copied" : label}</span>}
     </button>

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -441,26 +441,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         }
     };
 
-    const copyApiKey = async () => {
-        if (!apiKey) return;
-        try {
-            if (navigator.clipboard && window.isSecureContext) {
-                await navigator.clipboard.writeText(apiKey);
-            } else {
-                const textarea = document.createElement('textarea');
-                textarea.value = apiKey;
-                textarea.style.position = 'fixed';
-                textarea.style.opacity = '0';
-                document.body.appendChild(textarea);
-                textarea.select();
-                const ok = document.execCommand('copy');
-                document.body.removeChild(textarea);
-                if (!ok) throw new Error('Copy failed');
-            }
-            onNotify('API key copied.', 'success');
-        } catch {
-            onNotify('Copy failed.', 'error');
-        }
+    const copyApiKey = () => {
+        onNotify('API key copied.', 'success');
     };
 
     useEffect(() => {

--- a/src/components/settings/ApiKeyPanel.tsx
+++ b/src/components/settings/ApiKeyPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import MaterialIcon from '../MaterialIcon';
+import CopyButton from '../CopyButton';
 
 interface ApiKeyPanelProps {
     apiKey: string | null;
@@ -52,14 +53,14 @@ const ApiKeyPanel: React.FC<ApiKeyPanelProps> = ({ apiKey, loading, saving, onRe
                         )}
                         {saving ? (apiKey ? 'Rotating...' : 'Generating...') : (apiKey ? 'Rotate Key' : 'Generate Key')}
                     </button>
-                    <button
-                        onClick={onCopy}
+                    <CopyButton
+                        text={apiKey || ''}
+                        label="Copy Key"
                         disabled={!apiKey}
-                        className="flex-1 px-6 py-3 rounded-2xl text-[9px] font-bold uppercase tracking-widest border border-white/10 text-white hover:bg-white/5 transition-all disabled:opacity-50 inline-flex items-center justify-center gap-2"
-                    >
-                        <MaterialIcon name="content_copy" className="text-base" />
-                        Copy Key
-                    </button>
+                        onCopy={onCopy}
+                        className="flex-1 px-6 py-3 rounded-2xl text-[9px] font-bold uppercase tracking-widest border border-white/10 text-white hover:bg-white/5 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2"
+                        iconClassName="text-base"
+                    />
                 </div>
                 <p className="text-[9px] text-gray-600 uppercase tracking-widest">
                     Use this key in `key`, `x-api-key`, or `Authorization: Bearer` headers.


### PR DESCRIPTION
This PR refactors the "Copy Key" functionality in the API Key settings panel to use the reusable `CopyButton` component. This standardizes the copy interaction, providing consistent visual feedback (check icon) and improved accessibility (ARIA labels). It also removes duplicated clipboard handling code in `SettingsScreen`.

---
*PR created automatically by Jules for task [5203060814030216738](https://jules.google.com/task/5203060814030216738) started by @asernasr*