### PR TITLE
🎨 Palette: Add Ctrl+K shortcut for Action Palette

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doppelgangerdev/doppelganger",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@doppelgangerdev/doppelganger",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@doppelgangerdev/doppelganger",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-only",
       "dependencies": {

--- a/server.log
+++ b/server.log
@@ -1,0 +1,5 @@
+
+> @doppelgangerdev/doppelganger@0.7.2 start
+> node server.js
+
+Server running at http://localhost:11345

--- a/src/components/EditorScreen.tsx
+++ b/src/components/EditorScreen.tsx
@@ -486,6 +486,19 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
     }, []);
 
     useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+                e.preventDefault();
+                if (!actionPaletteOpen) {
+                    openActionPalette();
+                }
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [actionPaletteOpen, openActionPalette]);
+
+    useEffect(() => {
         const handlePointerMove = (event: PointerEvent) => {
             if (!resizingRef.current) return;
             const next = clampEditorWidth(event.clientX);
@@ -810,9 +823,12 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                         })()}
                                         <button
                                             onClick={() => openActionPalette()}
-                                            className="w-full py-3 border border-dashed border-white/20 rounded-xl text-[9px] font-bold uppercase tracking-widest text-gray-500 hover:text-white transition-all bg-white/[0.02]"
+                                            className="w-full py-3 border border-dashed border-white/20 rounded-xl text-[9px] font-bold uppercase tracking-widest text-gray-500 hover:text-white transition-all bg-white/[0.02] flex items-center justify-center gap-2"
                                         >
-                                            + Append Action Seq
+                                            <span>+ Append Action Seq</span>
+                                            <kbd className="hidden sm:inline-flex h-5 items-center gap-1 rounded border border-white/10 bg-white/5 px-1.5 font-mono text-[10px] font-medium text-white/50">
+                                                <span className="text-xs">⌘</span>K
+                                            </kbd>
                                         </button>
                                     </div>
 


### PR DESCRIPTION
Added a `Ctrl+K` (or `Cmd+K` on Mac) keyboard shortcut to quickly open the Action Palette in the task editor. This allows users to add actions without leaving the keyboard. Also updated the "Append Action Seq" button to include a `<kbd>` visual hint (`⌘K`) to make this shortcut discoverable. The change was verified with unit tests and a frontend Playwright script.

---
*PR created automatically by Jules for task [4981747026297572010](https://jules.google.com/task/4981747026297572010) started by @asernasr*