### PR TITLE
⚡ Bolt: [performance improvement] Memoize ResultsPane state to prevent flickering and network spam

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-28 - [Frontend Performance: CookiePanel Optimization]
 **Learning:** `CookiesPanel.tsx` previously re-rendered all cookies and executed expensive decoding logic (`decodeURIComponent`, `atob`, regex checks) on every re-render (e.g. expanding/collapsing a row), because this computation was tightly coupled with the loop inside the component render body.
 **Action:** Use `useMemo` to precalculate derived data structure for collections before the render `map` loop, particularly when components have internal state triggers that cause frequent re-renders.
+
+## 2025-02-28 - [Frontend Performance: ResultsPane Memoization]
+**Learning:** Using `Date.now()` unmemoized inside a React component's render body (e.g., for image cache busting) forces constant re-renders and image re-fetching whenever the parent component updates (like during drag-and-drop). Additionally, expensive data parsing functions like `getTableData` and `getResultsPreview` were unmemoized.
+**Action:** Wrap expensive derived state and volatile cache-busters (like `Date.now()`) in `useMemo` with appropriate dependency arrays. Ensure heavy sub-components are exported with `React.memo()`.

--- a/src/components/editor/ResultsPane.tsx
+++ b/src/components/editor/ResultsPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useMemo, memo } from 'react';
 import MaterialIcon from '../MaterialIcon';
 import { ConfirmRequest, Results, CaptureEntry } from '../../types';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
@@ -303,13 +303,13 @@ const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExe
     const [captures, setCaptures] = useState<CaptureEntry[]>([]);
     const headfulFrameRef = useRef<HTMLDivElement | null>(null);
     const activeResults = resultView === 'pinned' && pinnedResults ? pinnedResults : results;
-    const tableData = getTableData(activeResults?.data);
-    const preview = activeResults && activeResults.data !== undefined && activeResults.data !== null && activeResults.data !== ''
+    const tableData = useMemo(() => getTableData(activeResults?.data), [activeResults?.data]);
+    const preview = useMemo(() => activeResults && activeResults.data !== undefined && activeResults.data !== null && activeResults.data !== ''
         ? getResultsPreview(activeResults)
-        : null;
-    const screenshotSrc = activeResults?.screenshotUrl
+        : null, [activeResults]);
+    const screenshotSrc = useMemo(() => activeResults?.screenshotUrl
         ? `${activeResults.screenshotUrl}${resultView === 'latest' ? `?t=${Date.now()}` : ''}`
-        : null;
+        : null, [activeResults, resultView]);
     const renderCellValue = (value: any) => {
         const boolValue = normalizeBoolean(value);
         if (boolValue !== null) {
@@ -856,4 +856,4 @@ const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExe
     );
 };
 
-export default ResultsPane;
+export default memo(ResultsPane);


### PR DESCRIPTION
💡 What: The optimization implemented
Wrapped expensive data parsing functions (`getTableData` and `getResultsPreview`) in `useMemo`. Also wrapped the `screenshotSrc` cache-buster in `useMemo` dependent on `activeResults`, and applied `React.memo` to the component export. 

🎯 Why: The performance problem it solves
Because `Date.now()` was called continuously during the render loop, any state changes from the parent component (such as dragging items or resizing) triggered continuous UI re-renders and re-fetched the image due to the changing query param `?t=...`. 

📊 Impact: Expected performance improvement
Eliminates unneeded network requests (saving bandwidth) and halts CPU-bound parsing routines during unrelated application updates. Eliminates UI flickering when drag-and-drop takes place in the parent component.

🔬 Measurement: How to verify the improvement
Run the frontend application. Open an editor screen with a task that has a screenshot result. Perform a drag-and-drop action on an item in the task list while inspecting the network tab in browser DevTools. You should no longer see duplicate network requests for the screenshot image occurring during the drag interaction.

---
*PR created automatically by Jules for task [10845279385958828164](https://jules.google.com/task/10845279385958828164) started by @asernasr*