### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in API Keys Panel

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Icon-only buttons with titles need aria-labels
+**Learning:** Adding a `title` attribute to an icon-only button (e.g., `<button title="Delete"><Icon/></button>`) provides a tooltip on hover, but it is not consistently announced by all screen readers. An explicit `aria-label` is still required for robust accessibility.
+**Action:** When creating icon-only buttons, ensure both `title` (for visual users) and `aria-label` (for screen reader users) are present, or use visually hidden text.

--- a/src/components/settings/ApiKeysPanel.tsx
+++ b/src/components/settings/ApiKeysPanel.tsx
@@ -146,6 +146,7 @@ const ApiKeyRow: React.FC<{
                             disabled={config.loading || config.saving}
                             className="p-3 rounded-2xl bg-white/5 border border-white/10 text-red-400 hover:bg-red-500/20 hover:border-red-500/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                             title="Delete Key"
+                            aria-label="Delete Key"
                         >
                             <MaterialIcon name="delete" className="text-base" />
                         </button>
@@ -168,6 +169,7 @@ const ApiKeyRow: React.FC<{
                             type="button"
                             className="p-2 rounded-xl text-white/50 hover:text-white hover:bg-white/10 transition-all"
                             title={showPlaintext ? 'Hide value' : 'Show value'}
+                            aria-label={showPlaintext ? 'Hide value' : 'Show value'}
                         >
                             <MaterialIcon name={showPlaintext ? 'visibility_off' : 'visibility'} className="text-base" />
                         </button>
@@ -238,6 +240,7 @@ const ApiKeysPanel: React.FC<ApiKeysPanelProps> = ({ keys, availableProviders, o
                                     <button
                                         onClick={() => setShowAddMenu(false)}
                                         className="absolute top-6 right-6 p-3 rounded-2xl text-white/50 hover:text-white hover:bg-white/10 transition-all"
+                                        aria-label="Close"
                                     >
                                         <MaterialIcon name="close" className="text-2xl" />
                                     </button>


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to icon-only buttons in API Keys Panel

💡 **What:** Added `aria-label` attributes to the icon-only buttons in `ApiKeysPanel.tsx` (Delete Key, Show/Hide value, and Close modal).
🎯 **Why:** Icon-only buttons with just a `title` attribute are not always reliably announced by all screen readers. Providing an explicit `aria-label` ensures full keyboard and screen reader accessibility for these interactive elements.
♿ **Accessibility:** This ensures the buttons are properly described to assistive technologies, making the settings interface more usable for everyone.

---
*PR created automatically by Jules for task [6740930233732511341](https://jules.google.com/task/6740930233732511341) started by @asernasr*