### PR TITLE
⚡ Bolt: Memoize CaptureCard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-28 - [Frontend Performance: ResultsPane Memoization]
 **Learning:** Using `Date.now()` unmemoized inside a React component's render body (e.g., for image cache busting) forces constant re-renders and image re-fetching whenever the parent component updates (like during drag-and-drop). Additionally, expensive data parsing functions like `getTableData` and `getResultsPreview` were unmemoized.
 **Action:** Wrap expensive derived state and volatile cache-busters (like `Date.now()`) in `useMemo` with appropriate dependency arrays. Ensure heavy sub-components are exported with `React.memo()`.
+
+## 2024-05-24 - React-Window Item Memoization
+**Learning:** `react-window` supplies `itemData` to its item renderers. If the inner component (like `CaptureCard`) is not wrapped in `React.memo`, it will re-render even if its specific slice of `itemData` (e.g. `capture` and `onDelete`) hasn't changed, purely because the parent list re-rendered.
+**Action:** Always wrap components rendered inside `react-window` lists (e.g., `CaptureCard` inside `CapturesScreen` or `CapturesPanel`) with `React.memo()` to fully benefit from the stabilized `itemData` provided to the list.

--- a/src/components/CaptureCard.tsx
+++ b/src/components/CaptureCard.tsx
@@ -70,4 +70,6 @@ const CaptureCard: React.FC<CaptureCardProps> = ({ capture, onDelete }) => {
     );
 };
 
-export default CaptureCard;
+// ⚡ Bolt: Add React.memo() to prevent unnecessary re-renders when parent lists update.
+// CapturesScreen uses react-window which provides itemData with a stabilized onDelete callback.
+export default React.memo(CaptureCard);


### PR DESCRIPTION
💡 **What:** Added `React.memo()` to the `CaptureCard` component's export.
🎯 **Why:** `CapturesScreen` uses `react-window` to render large lists of captures. `react-window` supplies an `itemData` object containing the list of captures and callbacks (like `onDelete`). Without `React.memo()`, `CaptureCard` instances re-render whenever the parent list updates, even if their specific `capture` or the stable `onDelete` callback hasn't changed.
📊 **Impact:** Reduces unnecessary component re-renders during interactions (like deleting a different capture or scrolling, if item boundaries trigger updates) within `react-window` lists.
🔬 **Measurement:** Open the Captures screen, delete an item, and profile the render tree. Other `CaptureCard` instances will no longer re-render.

---
*PR created automatically by Jules for task [197018628942019180](https://jules.google.com/task/197018628942019180) started by @asernasr*