### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/EditorScreen.tsx
+++ b/src/components/EditorScreen.tsx
@@ -1330,6 +1330,7 @@ return JSON.stringify(links, null, 2);`}
                                 onClick={() => onStop?.()}
                                 className="w-12 h-12 rounded-2xl border border-white/10 text-white/80 hover:text-white hover:bg-white/10 transition-all flex items-center justify-center"
                                 title="Stop task"
+                                aria-label="Stop task"
                             >
                                 <MaterialIcon name="stop" className="text-base" />
                             </button>

--- a/src/components/editor/ActionItem.tsx
+++ b/src/components/editor/ActionItem.tsx
@@ -240,6 +240,7 @@ const ActionItem: React.FC<ActionItemProps> = memo(({
                                     onClick={() => setAiPromptOpen(false)}
                                     className="text-gray-500 hover:text-white transition-colors p-1 -mr-1"
                                     title="Close"
+                                    aria-label="Close"
                                 >
                                     <MaterialIcon name="close" className="text-[12px]" />
                                 </button>

--- a/src/components/editor/ResultsPane.tsx
+++ b/src/components/editor/ResultsPane.tsx
@@ -784,6 +784,7 @@ const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExe
                         onClick={() => onNotify('Preview truncated for performance.', 'error')}
                         className="absolute top-5 right-5 h-2.5 w-2.5 rounded-full bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.6)]"
                         title="Preview truncated"
+                        aria-label="Preview truncated"
                     />
                 )}
                 <div className="max-h-[70vh] overflow-y-auto custom-scrollbar pr-2 relative">


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to icon-only buttons

* 💡 What: Added `aria-label` attributes to icon-only buttons across EditorScreen, ResultsPane, and ActionItem.
* 🎯 Why: Icon-only buttons with just a `title` attribute are not consistently announced by all screen readers. Adding explicit `aria-label`s ensures robust accessibility for visually impaired users navigating via keyboard and screen readers.
* ♿ Accessibility: Improves WCAG compliance by ensuring interactive elements have a properly discernible name.

---
*PR created automatically by Jules for task [478237875639655433](https://jules.google.com/task/478237875639655433) started by @asernasr*