### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/editor/ActionItem.tsx
+++ b/src/components/editor/ActionItem.tsx
@@ -304,6 +304,7 @@ const ActionItem: React.FC<ActionItemProps> = memo(({
                                 disabled={action.disabled}
                                 className="text-purple-400 hover:text-purple-300 transition-colors focus:outline-none flex items-center justify-center opacity-50 hover:opacity-100 shrink-0 disabled:opacity-20 disabled:hover:opacity-20 disabled:cursor-not-allowed"
                                 title="AI Selector Finder"
+                                aria-label="AI Selector Finder"
                             >
                                 <MaterialIcon name="auto_awesome" className="text-lg" />
                             </button>

--- a/src/components/editor/ResultsPane.tsx
+++ b/src/components/editor/ResultsPane.tsx
@@ -817,6 +817,7 @@ const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExe
                                                     download={file.name}
                                                     className="shrink-0 p-3 rounded-lg border border-white/10 bg-white/5 text-white/80 hover:bg-white/10 hover:text-white transition-all flex items-center justify-center"
                                                     title="Download file"
+                                                    aria-label="Download file"
                                                 >
                                                     <MaterialIcon name="download" className="text-[18px]" />
                                                 </a>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to strictly icon-only buttons.
🎯 Why: To ensure screen readers can announce the purpose of elements that lack visible text, improving accessibility. 
📸 Before/After: Visuals remain unchanged, screen reader experience is improved.
♿ Accessibility: Added missing `aria-label` to strictly icon-only buttons in ActionItem and ResultsPane components.

---
*PR created automatically by Jules for task [14372133739160718510](https://jules.google.com/task/14372133739160718510) started by @asernasr*