### PR TITLE
⚡ Bolt: Memoize getBlockDepths in EditorScreen

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - React-Window Item Memoization
 **Learning:** `react-window` supplies `itemData` to its item renderers. If the inner component (like `CaptureCard`) is not wrapped in `React.memo`, it will re-render even if its specific slice of `itemData` (e.g. `capture` and `onDelete`) hasn't changed, purely because the parent list re-rendered.
 **Action:** Always wrap components rendered inside `react-window` lists (e.g., `CaptureCard` inside `CapturesScreen` or `CapturesPanel`) with `React.memo()` to fully benefit from the stabilized `itemData` provided to the list.
+
+## 2026-03-04 - [Frontend Performance: EditorScreen Memoization]
+**Learning:** Functions that derive state from large data structures (like `getBlockDepths` iterating over `currentTask.actions`) will be executed on every re-render if called directly in the component body. This causes O(N) recalculations even when the data structure hasn't changed (e.g., during drag-and-drop operations, variable edits, etc.). Also, do not use hooks inside `(() => {})()` statements!
+**Action:** Always wrap derived array calculations inside `useMemo` hooks, with the parent array as the dependency, to avoid unnecessary loop executions during React render cycles. Ensure it is placed directly at the top level of the function block.

--- a/src/components/EditorScreen.tsx
+++ b/src/components/EditorScreen.tsx
@@ -8,6 +8,8 @@ import JsonEditorPane from './editor/JsonEditorPane';
 import ResultsPane from './editor/ResultsPane';
 import ActionItem from './editor/ActionItem';
 
+const blockStartTypes = new Set(['if', 'while', 'repeat', 'foreach', 'on_error']);
+
 interface EditorScreenProps {
     currentTask: Task;
     setCurrentTask: Dispatch<SetStateAction<Task | null>>;
@@ -310,11 +312,10 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
         return () => clearTimeout(timeout);
     }, [currentTask]);
 
-    const blockStartTypes = new Set(['if', 'while', 'repeat', 'foreach', 'on_error']);
-
-    const getBlockDepths = (actions: Action[]) => {
+    // ⚡ Bolt: Memoize block depth array to prevent O(N) array mapping on every re-render (e.g., during drag operations)
+    const blockDepths = useMemo(() => {
         let depth = 0;
-        return actions.map((action) => {
+        return currentTask.actions.map((action) => {
             if (action.type === 'else' || action.type === 'end') {
                 depth = Math.max(0, depth - 1);
             }
@@ -324,7 +325,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
             }
             return currentDepth;
         });
-    };
+    }, [currentTask.actions]);
 
     const addActionByType = (type: Action['type']) => {
         const base: Action = {
@@ -848,7 +849,6 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                 <div className="space-y-6 order-1">
                                     <div className="space-y-3" ref={actionsListRef}>
                                         {(() => {
-                                            const blockDepths = getBlockDepths(currentTask.actions);
                                             return currentTask.actions.map((action, idx) => {
                                                 const isDragging = dragState?.id === action.id;
                                                 const isBetween =


### PR DESCRIPTION
💡 **What**: Refactored the calculation of `blockDepths` inside `EditorScreen` using `useMemo` at the component level, rather than calling it directly inside the JSX structure.

🎯 **Why**: The `getBlockDepths` function iterates over the entire `currentTask.actions` array. Because it was being called on every render, it led to O(N) array traversals each time the component state updated, such as dragging an item or editing variables.

📊 **Impact**: Reduces CPU overhead and redundant array mappings by caching the block depth results. The calculation will now strictly only run when `currentTask.actions` changes.

🔬 **Measurement**: Dragging operations in the editor with large sequences should see reduced frame blocking since React doesn't have to map the array multiple times per interaction cycle. Verify by loading a large task and inspecting frame timing in Chrome DevTools during drag events.

---
*PR created automatically by Jules for task [10300561103679515701](https://jules.google.com/task/10300561103679515701) started by @asernasr*