### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability by defaulting ALLOW_PRIVATE_NETWORKS to false

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-04 - Insecure Default for SSRF Prevention
+**Vulnerability:** The Server-Side Request Forgery (SSRF) mitigation flag (`ALLOW_PRIVATE_NETWORKS`) defaulted to `true`, rendering the application vulnerable to SSRF out-of-the-box by allowing requests to private IPs.
+**Learning:** Security controls that must be enabled or opted-into are prone to being skipped by users. By defaulting to true, the application's out-of-the-box state was insecure, requiring the user to explicitly secure it by passing env variables.
+**Prevention:** Always ensure that security features (like restricting access to private network IPs for agents) default to the most secure configuration (`false`), and make insecure behaviors strictly opt-in.

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -22,7 +22,7 @@ const SESSION_TTL_SECONDS = 10 * 365 * 24 * 60 * 60; // 10 years
 const NOVNC_PORT = Number(process.env.NOVNC_PORT) || 54311;
 const WEBSOCKIFY_PATH = '/websockify';
 
-const ALLOW_PRIVATE_NETWORKS = !['0', 'false', 'no'].includes(String(process.env.ALLOW_PRIVATE_NETWORKS || '').toLowerCase());
+const ALLOW_PRIVATE_NETWORKS = ['1', 'true', 'yes'].includes(String(process.env.ALLOW_PRIVATE_NETWORKS || '').toLowerCase());
 
 module.exports = {
     DEFAULT_PORT,

--- a/tests/private-network.test.js
+++ b/tests/private-network.test.js
@@ -19,7 +19,7 @@ async function runTests() {
         console.log('✓ SUCCESS: localhost blocked as expected');
     }
 
-    console.log('\nScenario 2: Flag DEFAULT (should be enabled)');
+    console.log('\nScenario 2: Flag DEFAULT (should be disabled)');
     delete process.env.ALLOW_PRIVATE_NETWORKS;
     delete require.cache[require.resolve('../src/server/constants')];
     delete require.cache[require.resolve('../url-utils')];
@@ -27,11 +27,10 @@ async function runTests() {
 
     try {
         await validateUrlDefault('http://localhost');
-        console.log('✓ SUCCESS: localhost allowed by default');
-    } catch (e) {
-        console.error('FAILED: localhost should be allowed by default');
-        console.error(e.message);
+        console.error('FAILED: localhost should be blocked by default');
         process.exit(1);
+    } catch (e) {
+        console.log('✓ SUCCESS: localhost blocked by default as expected');
     }
 
     console.log('\nScenario 3: Flag EXPLICITLY ENABLED');


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** The Server-Side Request Forgery (SSRF) mitigation flag (`ALLOW_PRIVATE_NETWORKS`) defaulted to `true`, rendering the application vulnerable to SSRF out-of-the-box by allowing requests to private IPs.
**Impact:** An attacker could use the agent to access internal services or scan internal networks due to the insecure default.
**Fix:** Modified `ALLOW_PRIVATE_NETWORKS` to default to `false` and require explicit opt-in (e.g. `process.env.ALLOW_PRIVATE_NETWORKS = 'true'`).
**Verification:** Verified by updating `tests/private-network.test.js` to assert the blocked-by-default behavior and passing all node script tests and the full `pnpm run test` suite. Recorded this learning to `.jules/sentinel.md` as instructed.

---
*PR created automatically by Jules for task [15344445857164039447](https://jules.google.com/task/15344445857164039447) started by @asernasr*