### PR TITLE
🧹 fix empty catch block in sandbox.js

### DIFF
--- a/src/agent/sandbox.js
+++ b/src/agent/sandbox.js
@@ -11,8 +11,9 @@ function createSafeProxy(target) {
     let shadowTarget = target;
     if (typeof target === 'function') {
         shadowTarget = function (...args) { };
-        try { Object.defineProperty(shadowTarget, 'name', { value: target.name, configurable: true }); } catch {}
-        try { Object.defineProperty(shadowTarget, 'length', { value: target.length, configurable: true }); } catch {}
+        // Best effort to copy function properties. If these fail (e.g. non-configurable), we ignore.
+        try { Object.defineProperty(shadowTarget, 'name', { value: target.name, configurable: true }); } catch (e) { /* ignore */ }
+        try { Object.defineProperty(shadowTarget, 'length', { value: target.length, configurable: true }); } catch (e) { /* ignore */ }
         shadowTarget[REAL_TARGET] = target;
     }
 

--- a/tests/sandbox-health.test.js
+++ b/tests/sandbox-health.test.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+// Mock JSDOM to avoid dependency issues in restricted environment if necessary,
+// but let's see if we can just mock the parts of sandbox.js we need or if we can get it to run.
+// Actually, createSafeProxy doesn't use JSDOM directly, but the file requires it.
+
+// We can try to mock the require of jsdom if it's missing.
+try {
+    require('jsdom');
+} catch (e) {
+    const Module = require('module');
+    const originalRequire = Module.prototype.require;
+    Module.prototype.require = function(name) {
+        if (name === 'jsdom') {
+            return { JSDOM: function() { return { window: {} }; } };
+        }
+        return originalRequire.apply(this, arguments);
+    };
+}
+
+const { createSafeProxy } = require('../src/agent/sandbox');
+
+async function testCreateSafeProxy() {
+    console.log('Testing createSafeProxy...');
+
+    // Test with a simple object
+    const obj = { a: 1, b: { c: 2 } };
+    const proxyObj = createSafeProxy(obj);
+    assert.strictEqual(proxyObj.a, 1);
+    assert.strictEqual(proxyObj.b.c, 2);
+    console.log('✓ Simple object proxy works');
+
+    // Test with a function
+    function testFn(x, y) {}
+    const proxyFn = createSafeProxy(testFn);
+    assert.strictEqual(typeof proxyFn, 'function');
+    assert.strictEqual(proxyFn.name, 'testFn');
+    assert.strictEqual(proxyFn.length, 2);
+    console.log('✓ Function proxy works and maintains name/length');
+
+    // Test property access and wrapping
+    const nestedObj = { getFn: () => (a, b, c) => {} };
+    const proxyNested = createSafeProxy(nestedObj);
+    const fn = proxyNested.getFn();
+    assert.strictEqual(typeof fn, 'function');
+    assert.strictEqual(fn.length, 3);
+    console.log('✓ Nested function proxy works');
+
+    console.log('All createSafeProxy tests passed!');
+}
+
+testCreateSafeProxy().catch(err => {
+    console.error('Test failed:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
This change improves the maintainability of \`src/agent/sandbox.js\` by addressing empty catch blocks as identified in the code health report. Explanatory comments were added to clarify that property assignment for 'name' and 'length' is a "best effort" and errors are expected and safely ignored if those properties are non-configurable. A new test file \`tests/sandbox-health.test.js\` was created to ensure no regressions were introduced to the proxy logic.

---
*PR created automatically by Jules for task [537937348238860522](https://jules.google.com/task/537937348238860522) started by @asernasr*