### PR TITLE
⚡ Bolt: Add React.memo() to MaterialIcon

### DIFF
--- a/src/components/MaterialIcon.tsx
+++ b/src/components/MaterialIcon.tsx
@@ -1,12 +1,15 @@
 
 
+import React from 'react';
+
 type MaterialIconProps = {
     name: string;
     className?: string;
     fill?: boolean;
 };
 
-export default function MaterialIcon({ name, className = '', fill = false }: MaterialIconProps) {
+// ⚡ Bolt: Add React.memo() to prevent unnecessary re-renders of this widely used static icon component.
+const MaterialIcon = React.memo(({ name, className = '', fill = false }: MaterialIconProps) => {
     return (
         <span
             className={`material-symbols-outlined ${className}`}
@@ -18,4 +21,6 @@ export default function MaterialIcon({ name, className = '', fill = false }: Mat
             {name}
         </span>
     );
-}
+});
+
+export default MaterialIcon;


### PR DESCRIPTION
💡 **What:** Wrapped the `MaterialIcon` functional component with `React.memo()`.

🎯 **Why:** The `MaterialIcon` is a purely presentational component that accepts only primitive props (`name`, `className`, `fill`). It is heavily used throughout the application (almost 100 times across `src/components`). Previously, it was unmemoized, which meant that any time a parent component re-rendered, all of its child `MaterialIcon` instances were forced to re-evaluate. 

📊 **Impact:** Reduces unnecessary functional component re-evaluations during React reconciliation cycles by skipping re-renders when the icon props have not changed. This will particularly help with overall application snappiness during heavy UI state updates, as it eliminates redundant DOM diffing for static icons.

🔬 **Measurement:** Can be verified via React DevTools Profiler by recording a render cycle on pages with heavy icon density (e.g., Settings, Editor) before and after the change; the `MaterialIcon` component should now appear as "Memoized" and skip rendering when its props remain static.

---
*PR created automatically by Jules for task [17431680745139559421](https://jules.google.com/task/17431680745139559421) started by @asernasr*