### PR TITLE
Hide browser viewer disclaimer when optimized

### DIFF
--- a/server.js
+++ b/server.js
@@ -363,22 +363,9 @@ app.use(express.static(DIST_DIR));
 
 // Headful Status Endpoint
 app.get('/api/headful/status', (req, res) => {
-    const detectContainer = () => {
-        try {
-            if (fs.existsSync('/.dockerenv')) return true;
-        } catch {
-            // ignore
-        }
-        try {
-            const cgroup = fs.readFileSync('/proc/1/cgroup', 'utf8');
-            if (/docker|kubepods|containerd|podman/i.test(cgroup)) return true;
-        } catch {
-            // ignore
-        }
-        return false;
-    };
-    const useNovnc = detectContainer() && novncEnabled;
-    res.json({ useNovnc });
+    // If noVNC is enabled (found on disk), we consider the environment optimized.
+    // This allows Docker and manual installations with proper deps to hide the disclaimer.
+    res.json({ useNovnc: novncEnabled });
 });
 
 // Start Server

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ export default function App() {
         results,
         setResults,
         activeRunId,
+        useNovnc,
         runTaskWithSnapshot,
         stopTask,
         openHeadful,
@@ -239,6 +240,7 @@ export default function App() {
                                 isHeadfulOpen={isHeadfulOpen}
                                 onOpenHeadful={(url) => openHeadful(url)}
                                 onStopHeadful={stopHeadful}
+                                useNovnc={useNovnc}
                             />
                         ) : <LoadingScreen title="Initializing" subtitle="Preparing task workspace" />
                     } />
@@ -269,6 +271,7 @@ export default function App() {
                                 isHeadfulOpen={isHeadfulOpen}
                                 onOpenHeadful={(url) => openHeadful(url)}
                                 onStopHeadful={stopHeadful}
+                                useNovnc={useNovnc}
                             />
                         }
                     />

--- a/src/components/EditorScreen.tsx
+++ b/src/components/EditorScreen.tsx
@@ -32,6 +32,7 @@ interface EditorScreenProps {
     isHeadfulOpen?: boolean;
     onOpenHeadful?: (url: string) => void;
     onStopHeadful?: () => void;
+    useNovnc?: boolean | null;
 }
 
 const _VariableRow: React.FC<{
@@ -121,6 +122,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
     isHeadfulOpen,
     onOpenHeadful,
     onStopHeadful,
+    useNovnc,
 }) => {
     const [_copied, setCopied] = useState<string | null>(null);
     const [contextMenu, setContextMenu] = useState<{ id: string; x: number; y: number } | null>(null);
@@ -1429,6 +1431,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                         onPin={onPinResults}
                         onUnpin={onUnpinResults}
                         fullWidth={true}
+                        useNovnc={useNovnc}
                     />
                 </div>
             </div>
@@ -1510,9 +1513,11 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                                     <div className="flex items-center gap-3">
                                         <span className="text-[10px] font-bold uppercase tracking-widest text-white">Active Browser Session</span>
                                     </div>
-                                    <span className="text-[10px] text-amber-500/80 max-w-md hidden sm:block">
-                                        Figranium is not optimized for native browser windows. Please install the proper tools for stability (Xvfb, x11vnc, websockify) or use Docker.
-                                    </span>
+                                    {useNovnc === false && (
+                                        <span className="text-[10px] text-amber-500/80 max-w-md hidden sm:block">
+                                            Figranium is not optimized for native browser windows. Please install the proper tools for stability (Xvfb, x11vnc, websockify) or use Docker.
+                                        </span>
+                                    )}
                                 </div>
                                 <div className="flex items-center gap-3">
                                     <button

--- a/src/components/ExecutionDetailScreen.tsx
+++ b/src/components/ExecutionDetailScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Execution, Results, ConfirmRequest } from '../types';
 import ResultsPane from './editor/ResultsPane';
+import { useHeadfulStatus } from '../hooks/useHeadfulStatus';
 
 interface ExecutionDetailScreenProps {
     onConfirm: (request: string | ConfirmRequest) => Promise<boolean>;
@@ -27,6 +28,7 @@ const ExecutionDetailScreen: React.FC<ExecutionDetailScreenProps> = ({ onConfirm
     const navigate = useNavigate();
     const [execution, setExecution] = useState<Execution | null>(null);
     const [loading, setLoading] = useState(false);
+    const useNovnc = useHeadfulStatus();
 
     useEffect(() => {
         const loadExecution = async () => {
@@ -102,6 +104,7 @@ const ExecutionDetailScreen: React.FC<ExecutionDetailScreenProps> = ({ onConfirm
                                 onConfirm={onConfirm}
                                 onNotify={onNotify}
                                 fullWidth
+                                useNovnc={useNovnc}
                             />
                         ) : (
                             <div className="text-[9px] text-gray-500 uppercase tracking-widest">No output captured.</div>

--- a/src/components/app/EditorLoader.tsx
+++ b/src/components/app/EditorLoader.tsx
@@ -29,6 +29,7 @@ interface EditorLoaderProps {
     isHeadfulOpen?: boolean;
     onOpenHeadful?: (url: string) => void;
     onStopHeadful?: () => void;
+    useNovnc?: boolean | null;
 }
 
 const EditorLoader: React.FC<EditorLoaderProps> = ({

--- a/src/components/editor/ResultsPane.tsx
+++ b/src/components/editor/ResultsPane.tsx
@@ -40,6 +40,7 @@ interface ResultsPaneProps {
     onPin?: (results: Results) => void;
     onUnpin?: () => void;
     fullWidth?: boolean;
+    useNovnc?: boolean | null;
 }
 
 const MAX_PREVIEW_CHARS = 60000;
@@ -292,12 +293,17 @@ const downloadText = (filename: string, content: string, mime: string) => {
     URL.revokeObjectURL(url);
 };
 
-const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExecuting, isHeadful, runId, onConfirm, onNotify, onPin, onUnpin, fullWidth }) => {
+const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExecuting, isHeadful, runId, onConfirm, onNotify, onPin, onUnpin, fullWidth, useNovnc }) => {
     const [copied, setCopied] = useState<string | null>(null);
     const [dataView, setDataView] = useState<'raw' | 'table'>('raw');
     const [mainView, setMainView] = useState<'data' | 'downloads'>('data');
     const [resultView, setResultView] = useState<'latest' | 'pinned'>(() => (pinnedResults && !results ? 'pinned' : 'latest'));
-    const [headfulViewer, setHeadfulViewer] = useState<'checking' | 'native' | 'novnc'>('checking');
+
+    const headfulViewer = useMemo(() => {
+        if (useNovnc === null) return 'checking';
+        return useNovnc ? 'novnc' : 'native';
+    }, [useNovnc]);
+
     const [capturesOpen, setCapturesOpen] = useState(false);
     const [capturesLoading, setCapturesLoading] = useState(false);
     const [captures, setCaptures] = useState<CaptureEntry[]>([]);
@@ -360,22 +366,6 @@ const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExe
         }
     }, [pinnedResults, resultView]);
 
-    useEffect(() => {
-        if (!isHeadful || resultView !== 'latest') return;
-        let cancelled = false;
-        const checkHeadful = async () => {
-            try {
-                const test = await fetch('/novnc/core/rfb.js', { method: 'HEAD', cache: 'no-store' });
-                if (!cancelled) setHeadfulViewer(test.ok ? 'novnc' : 'native');
-            } catch {
-                if (!cancelled) setHeadfulViewer('native');
-            }
-        };
-        checkHeadful();
-        return () => {
-            cancelled = true;
-        };
-    }, [isHeadful, resultView]);
 
     const handleCopy = async (text: string, id: string, options?: { skipSizeConfirm?: boolean; truncatedNotice?: boolean }) => {
         if (!text) {

--- a/src/hooks/useExecution.ts
+++ b/src/hooks/useExecution.ts
@@ -2,12 +2,14 @@ import { useState, useRef } from 'react';
 import { Task, Results } from '../types';
 import { formatExecutionError, isDisplayUnavailable } from '../utils/executionUtils';
 import { ensureActionIds } from '../utils/taskUtils';
+import { useHeadfulStatus } from './useHeadfulStatus';
 
 export function useExecution(showAlert: (msg: string, tone?: 'success' | 'error') => void) {
     const [isExecuting, setIsExecuting] = useState(false);
     const [isHeadfulOpen, setIsHeadfulOpen] = useState(false);
     const [results, setResults] = useState<Results | null>(null);
     const [activeRunId, setActiveRunId] = useState<string | null>(null);
+    const useNovnc = useHeadfulStatus();
     const executeAbortRef = useRef<AbortController | null>(null);
 
     const stopHeadful = async () => {
@@ -231,6 +233,7 @@ export function useExecution(showAlert: (msg: string, tone?: 'success' | 'error'
         results,
         setResults,
         activeRunId,
+        useNovnc,
         runTaskWithSnapshot,
         stopTask,
         openHeadful,

--- a/src/hooks/useHeadfulStatus.ts
+++ b/src/hooks/useHeadfulStatus.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+export function useHeadfulStatus() {
+    const [useNovnc, setUseNovnc] = useState<boolean | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const checkStatus = async () => {
+            try {
+                const res = await fetch('/api/headful/status');
+                if (res.ok) {
+                    const data = await res.json();
+                    if (!cancelled) setUseNovnc(!!data.useNovnc);
+                } else {
+                    if (!cancelled) setUseNovnc(false);
+                }
+            } catch {
+                if (!cancelled) setUseNovnc(false);
+            }
+        };
+        checkStatus();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return useNovnc;
+}


### PR DESCRIPTION
This change hides the "unoptimized" disclaimer in the browser viewer when the environment supports optimized headful sessions (e.g., in Docker with noVNC/websockify). It introduces a centralized `/api/headful/status` endpoint and a `useHeadfulStatus` hook to propagate this state across the frontend components.

---
*PR created automatically by Jules for task [14049963274255174610](https://jules.google.com/task/14049963274255174610) started by @asernasr*