### PR TITLE
Remove redundant page helper labels

### DIFF
--- a/server_output.log
+++ b/server_output.log
@@ -1,5 +1,0 @@
-
-> @doppelgangerdev/doppelganger@0.9.0 start /app
-> node server.js
-
-Server running at http://localhost:11345

--- a/src/components/CapturesScreen.tsx
+++ b/src/components/CapturesScreen.tsx
@@ -76,7 +76,6 @@ const CapturesScreen: React.FC<CapturesScreenProps> = ({ onConfirm, onNotify }) 
             <div className="max-w-6xl mx-auto space-y-8">
                 <div className="flex items-end justify-between">
                     <div className="space-y-2">
-                        <p className="text-[10px] font-bold text-blue-400 uppercase tracking-[0.4em]">Captures</p>
                         <h2 className="text-3xl font-bold tracking-tighter text-white">All Captures</h2>
                         <div className="text-[8px] text-gray-500 uppercase tracking-[0.2em]">
                             Recordings and screenshots from every run

--- a/src/components/ExecutionDetailScreen.tsx
+++ b/src/components/ExecutionDetailScreen.tsx
@@ -77,7 +77,6 @@ const ExecutionDetailScreen: React.FC<ExecutionDetailScreenProps> = ({ onConfirm
             <div className="max-w-6xl mx-auto space-y-8">
                 <div className="flex items-end justify-between">
                     <div className="space-y-2">
-                        <p className="text-[10px] font-bold text-blue-400 uppercase tracking-[0.4em]">Execution</p>
                         <h2 className="text-3xl font-bold tracking-tighter text-white">{execution.taskName || execution.mode}</h2>
                         <div className="text-[8px] text-gray-500 uppercase tracking-[0.2em]">
                             {new Date(execution.timestamp).toLocaleString()} | {execution.source} | {execution.mode} | {execution.status} | {execution.durationMs}ms

--- a/src/components/ExecutionsScreen.tsx
+++ b/src/components/ExecutionsScreen.tsx
@@ -133,7 +133,6 @@ const ExecutionsScreen: React.FC<ExecutionsScreenProps> = ({ onConfirm, onNotify
             <div className="max-w-6xl mx-auto space-y-8">
                 <div className="flex items-end justify-between">
                     <div className="space-y-2">
-                        <p className="text-[10px] font-bold text-blue-400 uppercase tracking-[0.4em]">Executions</p>
                         <h2 className="text-4xl font-bold tracking-tighter text-white">Run History</h2>
                     </div>
                     <div className="flex items-center gap-3">

--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -7,7 +7,6 @@ const SettingsHeader: React.FC<SettingsHeaderProps> = ({ tab, onTabChange }) => 
     return (
         <div className="flex items-end justify-between mb-8">
             <div className="space-y-2">
-                <p className="text-[10px] font-bold text-purple-500 uppercase tracking-[0.4em]">System</p>
                 <h2 className="text-4xl font-bold tracking-tighter text-white">Settings</h2>
             </div>
             <div className="flex bg-white/5 rounded-xl p-1 border border-white/5">


### PR DESCRIPTION
This change removes several redundant, uppercase "helper" labels from screen headers (e.g., 'System' in Settings, 'Executions' in Run History) that were identified as "useless page helper things". 

Specifically modified:
- `src/components/settings/SettingsHeader.tsx` (Removed 'System')
- `src/components/ExecutionsScreen.tsx` (Removed 'Executions')
- `src/components/ExecutionDetailScreen.tsx` (Removed 'Execution')
- `src/components/CapturesScreen.tsx` (Removed 'Captures')

Labels for 'Add Block' in the Action Palette and '404' in the Not Found screen were intentionally left untouched as per user feedback.

---
*PR created automatically by Jules for task [1785788764695979631](https://jules.google.com/task/1785788764695979631) started by @asernasr*