### PR TITLE
Remove blue cursor overlay in headful mode

### DIFF
--- a/headful.js
+++ b/headful.js
@@ -5,7 +5,6 @@ const { getProxySelection } = require('./proxy-rotation');
 const { selectUserAgent } = require('./user-agent-settings');
 const { validateUrl } = require('./url-utils');
 const { parseBooleanFlag } = require('./common-utils');
-const { installMouseHelper } = require('./src/agent/dom-utils');
 const { Mutex } = require('./src/server/utils');
 
 const headfulMutex = new Mutex();
@@ -134,7 +133,6 @@ async function runHeadful(data, options = {}) {
             document.addEventListener('click', handleLinkClick, true);
             document.addEventListener('auxclick', handleLinkClick, true);
         });
-        await context.addInitScript(installMouseHelper);
 
         const page = await context.newPage();
 


### PR DESCRIPTION
Removed the injection of `installMouseHelper` from `headful.js`. This visual aid is primarily intended for headless recordings and is redundant in headful mode where a real cursor is typically present or managed. Headless modes (Agent and Scrape) still retain the helper for visual feedback in screenshots and videos.

---
*PR created automatically by Jules for task [16029389750214155770](https://jules.google.com/task/16029389750214155770) started by @asernasr*