### PR TITLE
Fix Task Import Flexibility and Multi-file Support

### DIFF
--- a/src/components/DashboardScreen.tsx
+++ b/src/components/DashboardScreen.tsx
@@ -32,9 +32,9 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ tasks, onNewTask, onE
     };
 
     const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0];
-        if (file) {
-            onImportTasks(file);
+        const files = Array.from(event.target.files || []);
+        if (files.length > 0) {
+            files.forEach(file => onImportTasks(file));
         }
         event.target.value = '';
     };
@@ -82,6 +82,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ tasks, onNewTask, onE
                                 ref={fileInputRef}
                                 type="file"
                                 accept="application/json"
+                                multiple
                                 className="hidden"
                                 onChange={handleFileChange}
                             />

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -139,16 +139,28 @@ export function useTasks(
         try {
             const text = await file.text();
             const parsed = JSON.parse(text);
-            const list = Array.isArray(parsed) ? parsed : parsed?.tasks;
-            if (!Array.isArray(list)) {
+            let list: any[] = [];
+            if (Array.isArray(parsed)) {
+                list = parsed;
+            } else if (parsed && typeof parsed === 'object') {
+                if (Array.isArray(parsed.tasks)) {
+                    list = parsed.tasks;
+                } else if (parsed.name || parsed.actions) {
+                    // Looks like a single task object
+                    list = [parsed];
+                }
+            }
+
+            if (list.length === 0) {
                 showAlert('Invalid import file.', 'error');
                 return;
             }
+
             const stamp = Date.now();
             const prepared = list
                 .map((raw, index) => normalizeImportedTask(raw, index))
                 .filter((task): task is Task => !!task)
-                .map((task) => (task.id ? task : { ...task, id: `task_${stamp}` }));
+                .map((task, index) => (task.id ? task : { ...task, id: `task_${stamp}_${index}` }));
 
             if (prepared.length === 0) {
                 showAlert('No tasks to import.', 'error');


### PR DESCRIPTION
The task import functionality was previously limited and prone to ID collisions. I've updated the `useTasks` hook to flexibly handle various JSON structures (single tasks, arrays, or task collections) and ensured that every imported task gets a unique ID. Additionally, I've enabled multiple file selection in the dashboard, allowing users to import several task files at once. These changes were verified using a Playwright script that simulated batch file uploads and confirmed the tasks appeared correctly in the dashboard.

---
*PR created automatically by Jules for task [14651165968510661326](https://jules.google.com/task/14651165968510661326) started by @asernasr*