### PR TITLE
⚡ Bolt: Optimize cache-busting logic in ResultsPane

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,6 +6,10 @@
 **Learning:** Using `Date.now()` unmemoized inside a React component's render body (e.g., for image cache busting) forces constant re-renders and image re-fetching whenever the parent component updates (like during drag-and-drop). Additionally, expensive data parsing functions like `getTableData` and `getResultsPreview` were unmemoized.
 **Action:** Wrap expensive derived state and volatile cache-busters (like `Date.now()`) in `useMemo` with appropriate dependency arrays. Ensure heavy sub-components are exported with `React.memo()`.
 
+## 2025-03-05 - [Frontend Performance: Fine-grained Dependency Arrays]
+**Learning:** Even when a cache-buster like `Date.now()` is correctly wrapped in `useMemo`, an overly broad dependency array (like the entire `activeResults` object instead of specifically `activeResults.screenshotUrl`) causes unnecessary recalculations when unrelated fields (like streaming `logs`) update. This leads to continuous image re-fetching and flickering DOM updates.
+**Action:** Always scope `useMemo` dependencies as narrowly as possible, using scalar primitives or specific sub-properties rather than parent objects, especially when dealing with data streams or frequent sub-state updates.
+
 ## 2024-05-24 - React-Window Item Memoization
 **Learning:** `react-window` supplies `itemData` to its item renderers. If the inner component (like `CaptureCard`) is not wrapped in `React.memo`, it will re-render even if its specific slice of `itemData` (e.g. `capture` and `onDelete`) hasn't changed, purely because the parent list re-rendered.
 **Action:** Always wrap components rendered inside `react-window` lists (e.g., `CaptureCard` inside `CapturesScreen` or `CapturesPanel`) with `React.memo()` to fully benefit from the stabilized `itemData` provided to the list.

--- a/src/components/editor/ResultsPane.tsx
+++ b/src/components/editor/ResultsPane.tsx
@@ -313,9 +313,10 @@ const ResultsPane: React.FC<ResultsPaneProps> = ({ results, pinnedResults, isExe
     const preview = useMemo(() => activeResults && activeResults.data !== undefined && activeResults.data !== null && activeResults.data !== ''
         ? getResultsPreview(activeResults)
         : null, [activeResults]);
+    // ⚡ Bolt: Cache bust screenshotUrl only when the url itself changes, not when other activeResults fields (like logs) update
     const screenshotSrc = useMemo(() => activeResults?.screenshotUrl
         ? `${activeResults.screenshotUrl}${resultView === 'latest' ? `?t=${Date.now()}` : ''}`
-        : null, [activeResults, resultView]);
+        : null, [activeResults?.screenshotUrl, resultView]);
     const renderCellValue = (value: any) => {
         const boolValue = normalizeBoolean(value);
         if (boolValue !== null) {


### PR DESCRIPTION
- Narrowed useMemo dependencies in `ResultsPane.tsx` from `[activeResults, resultView]` to `[activeResults?.screenshotUrl, resultView]` to prevent over-evaluating `Date.now()` cache buster.
- Added a learning entry to `.jules/bolt.md`.