### PR TITLE
Remove 'Initializing System' text from signup screen

### DIFF
--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -32,11 +32,6 @@ const AuthScreen: React.FC<AuthScreenProps> = ({ status, onSubmit, error, busy =
                     <p className="text-[9px] font-bold text-gray-500 uppercase tracking-[0.2em] leading-relaxed max-w-[200px] mx-auto">
                         Deterministic Control for an Agentic World
                     </p>
-                    {status === 'setup' && (
-                        <p className="text-[10px] font-bold text-accent uppercase tracking-[0.3em]">
-                            Initializing System
-                        </p>
-                    )}
                 </div>
 
                 <form onSubmit={handleSubmit} className="space-y-8">


### PR DESCRIPTION
Removed the 'Initializing System' text from the signup (setup) screen in `src/components/AuthScreen.tsx`. Verified the change with a Playwright script and screenshot.

---
*PR created automatically by Jules for task [15188548126407249523](https://jules.google.com/task/15188548126407249523) started by @asernasr*