### PR TITLE
Fix On Execution action block collapsing after autosave

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ export default function App() {
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
     const lastSavedSnapshot = useRef('');
     const [editorView, setEditorView] = useState<ViewMode>('visual');
+    const [triggerExpanded, setTriggerExpanded] = useState(false);
     const [pinnedResultsByTask, setPinnedResultsByTask] = useState<Record<string, Results>>({});
 
     const pinnedResultsKey = 'doppelganger.pinnedResults';
@@ -179,10 +180,12 @@ export default function App() {
     }, [navigate]);
 
     const handleNewTask = useCallback(() => {
+        setTriggerExpanded(false);
         createNewTask(setResults, setHasUnsavedChanges);
     }, [createNewTask, setResults, setHasUnsavedChanges]);
 
     const handleEditTask = useCallback((task: Task) => {
+        setTriggerExpanded(false);
         editTask(task, markTaskAsSaved, setResults);
     }, [editTask, markTaskAsSaved, setResults]);
 
@@ -268,6 +271,8 @@ export default function App() {
                                 tasks={tasks}
                                 editorView={editorView}
                                 setEditorView={setEditorView}
+                                triggerExpanded={triggerExpanded}
+                                setTriggerExpanded={setTriggerExpanded}
                                 isExecuting={isExecuting}
                                 onSave={handleSaveTask}
                                 onRun={() => runTaskWithSnapshot(currentTask, currentTask, setCurrentTask)}
@@ -298,6 +303,8 @@ export default function App() {
                                 setCurrentTask={setCurrentTask}
                                 editorView={editorView}
                                 setEditorView={setEditorView}
+                                triggerExpanded={triggerExpanded}
+                                setTriggerExpanded={setTriggerExpanded}
                                 isExecuting={isExecuting}
                                 onSave={handleSaveTask}
                                 onRun={() => runTaskWithSnapshot(currentTask, currentTask, setCurrentTask)}

--- a/src/components/EditorScreen.tsx
+++ b/src/components/EditorScreen.tsx
@@ -25,6 +25,8 @@ interface EditorScreenProps {
     tasks?: Task[];
     editorView: ViewMode;
     setEditorView: (view: ViewMode) => void;
+    triggerExpanded: boolean;
+    setTriggerExpanded: Dispatch<SetStateAction<boolean>>;
     isExecuting: boolean;
     onSave: (task?: Task, createVersion?: boolean) => Promise<void>;
     onRun: () => void;
@@ -47,6 +49,8 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
     currentTask,
     setCurrentTask,
     tasks = [],
+    triggerExpanded,
+    setTriggerExpanded,
     isExecuting,
     onSave,
     onRun,
@@ -88,7 +92,6 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
     const [actionPaletteInsertIndex, setActionPaletteInsertIndex] = useState<number | null>(null);
     const [actionStatusById, setActionStatusById] = useState<Record<string, 'running' | 'success' | 'error' | 'skipped'>>({});
     const [isResultsOpen, setIsResultsOpen] = useState(false);
-    const [triggerExpanded, setTriggerExpanded] = useState(false);
     const [selectedNoteIds, setSelectedNoteIds] = useState<Set<string>>(new Set());
 
     useEffect(() => {

--- a/src/components/app/EditorLoader.tsx
+++ b/src/components/app/EditorLoader.tsx
@@ -13,6 +13,8 @@ interface EditorLoaderProps {
     setCurrentTask: Dispatch<SetStateAction<Task | null>>;
     editorView: any;
     setEditorView: any;
+    triggerExpanded: boolean;
+    setTriggerExpanded: Dispatch<SetStateAction<boolean>>;
     isExecuting: boolean;
     onSave: (task?: Task, createVersion?: boolean) => Promise<void>;
     onRun: () => void;


### PR DESCRIPTION
## Summary

Fixes the issue where the **On Execution** action block collapsed when moving focus from the **URL** field to the **Wait (Sec)** field on a newly created task.

## Root Cause

The URL field's `onBlur` triggered autosave, which created the task and navigated from `/tasks/new` to `/tasks/:id`. This route transition remounted `EditorScreen`, causing the local `triggerExpanded` state to reset and the action block to collapse.

## Fix

* Lifted `triggerExpanded` state so it survives the `/tasks/new` → `/tasks/:id` transition.
* Removed the local `triggerExpanded` state from `EditorScreen`.
* Reset the expanded state only when explicitly creating a new task or opening a different task.

## Testing

* Reproduced the issue in Chrome.
* Verified the action block remains expanded when moving focus from **URL** to **Wait (Sec)**.
* Verified the application runs successfully after the change.
