### PR TITLE
Add secret task variables redacted from logs, results, history and ca…

### DIFF
--- a/AGENT_SPEC.md
+++ b/AGENT_SPEC.md
@@ -28,6 +28,7 @@ This document is a concise, implementation-focused reference for AI agents that 
   },
   "actions": [],
   "variables": {},
+  "redactCaptures": true,
   "schedule": {
     "enabled": false,
     "frequency": "daily",
@@ -69,6 +70,8 @@ Reserved:
 - `{$now}` resolves to ISO timestamp
 - `block.output` contains last block output
 - `loop.index`, `loop.count`, `loop.item`, `loop.text`, `loop.html` during foreach
+
+Variables holding passwords, tokens, or card numbers should be marked secret — see **§16 Sensitive variables**.
 
 ## 4) JavaScript action context
 The `javascript` action runs **inside the page** (browser context), not Node.
@@ -298,8 +301,50 @@ Extract the visible text content (`innerText`) of a page or a specific element a
 - `selector`: Optional CSS selector. If omitted, returns the full page body text.
 - `varName`: Optional variable name to store the result. Also available as `{$block.output}` in the next action.
 
-## 16) Notes for AI agents
+## 16) Sensitive variables (secrets)
+Mark a variable `secret: true` when it holds a password, token, API key, or card number.
+
+```json
+{
+  "variables": {
+    "username": { "type": "string", "value": "ada@example.com" },
+    "password": { "type": "string", "value": "correct-horse", "secret": true }
+  }
+}
+```
+
+The value is used normally during execution — it is typed into forms, sent in headers, and templated with `{$password}` like any other variable. What changes is everything that leaves the run:
+
+- **Logs** — every occurrence is replaced with `[REDACTED]`, including the `Typing into #pw: …` line.
+- **API response** — the returned `logs`, `html`, `data`, and `final_url` are redacted, so a secret echoed back by the target page (`value` attributes survive DOM cleaning) does not reach the caller.
+- **Execution history** — the stored `taskSnapshot.variables` keeps secret entries but replaces their values with `[REDACTED]`; the stored result is the already-redacted response.
+- **Webhooks and output providers** — both receive the redacted result.
+- **Screenshots and recordings** — the target field is visually masked *before* the value is typed, so plaintext never renders into a capture. Disable per task with `"redactCaptures": false`.
+- **Child tasks** — the `start` action forwards the secret variable names, so the child run redacts the same values.
+- **Task exports** — exported JSON keeps the variable and its `secret` flag but blanks the value.
+
+Redaction is exact-value matching, which also covers derived values: copying a secret into another variable, or embedding it in a larger string, still matches.
+
+**Limits worth knowing:**
+- Values shorter than 4 characters are **not** redacted — a 1–2 character secret would match nearly every log line. Use a longer value or accept that it stays visible.
+- Redaction applies to output, not to storage. Secret values are stored in `data/tasks.json` in plaintext, like Baserow credential tokens. Protect the `data/` directory accordingly.
+- Masking a capture depends on the page: it covers the field being typed into, not a value the site later renders somewhere else on the page.
+
+To flag a value captured at runtime — an OTP read off the page, a token from an API response — set `secret` on the `set` action:
+
+```json
+{ "id": "act_set_otp", "type": "set", "varName": "otp", "value": "{$block.output}", "secret": true }
+```
+
+When calling the API, pass secret variables in the request body like any other variable:
+
+```json
+{ "variables": { "password": "correct-horse" } }
+```
+
+## 17) Notes for AI agents
 - `javascript` actions are page-context only (no `page` object).
 - Prefer structured conditions for selectors (`exists` with selector).
 - Keep waits short; use 1-2s unless the target site is slow.
 - Always close block structures with `end`.
+- Mark any password, token, or card-number variable `secret: true` (§16). Never inline such a value directly in an action — put it in a secret variable and reference it with `{$name}`, or it will not be redacted.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Figranium includes a built-in scheduler that handles automated task execution wi
 - [ ] **Workspace templates** — allow saving and sharing workspace presets (layout + default proxies/agents) so new team members can onboard with pre-configured setups.
 - [ ] **Geo-targeted exits** — allow choosing proxy regions for tasks so you can pin the apparent location before running a job.
 - [x] **Complete anti-detection coverage** — follow browserscan.net's anti-detection checklist (fingerprints, headers, fonts, WebRTC, etc.) so automated runs mimic real browsers across task executions.
-- [ ] **Session recording redaction** — add toggles to redact sensitive fields (passwords, credit cards) from recordings/logs before storing them.
+- [x] **Session recording redaction** — task variables can be flagged **Secret** in the Vars tab. The value is still used at runtime, but every occurrence is replaced with `[REDACTED]` in logs, API responses, execution history, webhooks and output pushes, and the field is masked on screen before typing so it never reaches screenshots or recordings. See `AGENT_SPEC.md` §16.
 - [ ] **Two-factor authentication** — add optional TOTP/second-factor support to Settings/Auth so operators can lock down the UI with 2FA.
 - [ ] **Automatic self-healing selectors** — add selector fallback and recovery logic so tasks can repair broken locators after layout changes without manual intervention.
 - [ ] **AI-assisted fixing** — add an “AI auto-fix” helper that suggests layout, selector, and proxy tweaks after failed runs, letting teams approve or discard the proposed changes without switching contexts.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,5 +11,16 @@ We will acknowledge receipt within 24 hours, work with you privately, and post a
 ## Supported Versions
 We consider the `main` branch the supported release train. Please verify against that branch with your reproduction steps.
 
+## Handling Sensitive Task Data
+Task variables can be flagged **Secret** (Vars tab, or `"secret": true` in the task JSON). Secret values are redacted from logs, API responses, execution history, webhook payloads, output-provider pushes, and screen captures — see `AGENT_SPEC.md` §16 for the full list and its limits.
+
+Redaction protects **output**, not storage. Secret values are written to `data/tasks.json` (or the `tasks` table under `DB_TYPE=postgres`) in plaintext, the same as Baserow credential tokens, because the automation has to replay them. Treat `data/` as a secret store: restrict filesystem permissions, keep it out of version control (it is already gitignored), and encrypt backups.
+
+Task **export** files never contain secret values — the variable and its flag are exported with an empty value, so refill it after importing.
+
+Two related notes:
+- Values shorter than 4 characters are not redacted — the match would be too broad to be useful. Use longer values for anything that matters.
+- A secret typed into a page can still be exposed by the target site itself (for example, if it echoes the value into a different part of the page after submission). Masking covers the field being typed into.
+
 ## Response Process
 We strive to provide a fix or mitigation instructions within three business days. If a fix takes longer, we will keep you updated on progress and ETA.

--- a/headful.js
+++ b/headful.js
@@ -85,7 +85,16 @@ async function runHeadful(data, options = {}) {
         if (data.targetActionId && data.taskSnapshot) {
             const { runFigranite } = require('./src/agent/figranite');
             try {
-                const reqScope = { ...data.taskSnapshot, variables: data.variables || data.taskVariables || {}, statelessExecution: true, disableRecording: true };
+                const reqScope = {
+                    ...data.taskSnapshot,
+                    variables: data.variables || data.taskVariables || {},
+                    // taskSnapshot keeps the `secret` flags; pass any explicit
+                    // names through as well so the handoff run redacts too.
+                    taskSnapshot: data.taskSnapshot,
+                    secretVars: data.secretVars,
+                    statelessExecution: true,
+                    disableRecording: true
+                };
                 if (data.url) reqScope.url = data.url;
 
                 const result = await runFigranite(reqScope, {

--- a/redaction.js
+++ b/redaction.js
@@ -1,0 +1,211 @@
+// Redaction of sensitive variable values from logs, results, and stored history.
+//
+// Variables marked `secret: true` still need their real value at execution time
+// (they get typed into forms, sent as headers, etc.), so the value itself is
+// never transformed. Instead every outbound surface — log lines, API responses,
+// execution history, webhooks, output providers — is passed through a redactor
+// built from the run's secret values.
+
+const MASK = '[REDACTED]';
+
+// Values shorter than this are ignored: a one or two character secret would
+// match nearly every log line and destroy the output it is meant to protect.
+const MIN_SECRET_LENGTH = 4;
+
+// Cycles are handled by the WeakSet; this is a backstop against pathological
+// nesting. Deep enough that real extraction payloads are never truncated.
+const MAX_DEPTH = 64;
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const stringifySecret = (value) => {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Build a redactor over a set of secret values.
+ *
+ * @param {Array<any>} values Raw secret values (strings, numbers, or objects).
+ * @param {object} [opts]
+ * @param {(msg: string) => void} [opts.onSkip] Called once per value that is too short to redact safely.
+ * @returns {{ redact: Function, redactString: Function, addSecret: Function, hasSecrets: Function, size: number }}
+ */
+const createRedactor = (values = [], opts = {}) => {
+    const secrets = new Set();
+    let pattern = null;
+    const onSkip = typeof opts.onSkip === 'function' ? opts.onSkip : null;
+    const skipped = new Set();
+
+    const rebuild = () => {
+        if (secrets.size === 0) {
+            pattern = null;
+            return;
+        }
+        // Longest first so an overlapping shorter secret can't mask part of a
+        // longer one and leave the remainder exposed.
+        const sorted = Array.from(secrets).sort((a, b) => b.length - a.length);
+        pattern = new RegExp(sorted.map(escapeRegExp).join('|'), 'g');
+    };
+
+    const addSecret = (value) => {
+        const text = stringifySecret(value);
+        if (text === null) return false;
+        if (text.trim().length < MIN_SECRET_LENGTH) {
+            if (onSkip && text.trim() && !skipped.has(text)) {
+                skipped.add(text);
+                onSkip(`Secret value ignored for redaction: values shorter than ${MIN_SECRET_LENGTH} characters are too short to redact safely.`);
+            }
+            return false;
+        }
+        if (secrets.has(text)) return false;
+        secrets.add(text);
+        rebuild();
+        return true;
+    };
+
+    (Array.isArray(values) ? values : [values]).forEach(addSecret);
+
+    const redactString = (input) => {
+        if (!pattern || typeof input !== 'string' || input.length === 0) return input;
+        pattern.lastIndex = 0;
+        return input.replace(pattern, MASK);
+    };
+
+    const redact = (input, depth = 0, seen = null) => {
+        if (!pattern) return input;
+        if (typeof input === 'string') return redactString(input);
+        if (input === null || typeof input !== 'object') return input;
+        if (depth >= MAX_DEPTH) return input;
+
+        const visited = seen || new WeakSet();
+        if (visited.has(input)) return input;
+        visited.add(input);
+
+        if (Array.isArray(input)) {
+            return input.map((item) => redact(item, depth + 1, visited));
+        }
+
+        // Leave exotic objects (Date, Buffer, Map, class instances) untouched —
+        // rebuilding them as plain objects would corrupt the payload.
+        const proto = Object.getPrototypeOf(input);
+        if (proto !== Object.prototype && proto !== null) return input;
+
+        const out = {};
+        for (const [key, value] of Object.entries(input)) {
+            out[redactString(key)] = redact(value, depth + 1, visited);
+        }
+        return out;
+    };
+
+    return {
+        redact,
+        redactString,
+        addSecret,
+        hasSecrets: () => secrets.size > 0,
+        get size() { return secrets.size; }
+    };
+};
+
+/**
+ * Pull the values of secret variables out of a task's variable map.
+ *
+ * Accepts both the editor shape (`{ name: { type, value, secret } }`) and the
+ * flattened runtime shape (`{ name: value }`) paired with an explicit list of
+ * secret variable names.
+ *
+ * @param {object} variables
+ * @param {string[]} [secretVarNames] Names to treat as secret in the flattened shape.
+ * @returns {any[]}
+ */
+const collectSecretValues = (variables, secretVarNames = []) => {
+    const values = [];
+    if (!variables || typeof variables !== 'object') return values;
+    const names = new Set(Array.isArray(secretVarNames) ? secretVarNames.map(String) : []);
+
+    for (const [name, entry] of Object.entries(variables)) {
+        // Editor shape is { type, value, secret? }. Requiring `type` or `secret`
+        // alongside `value` avoids mistaking a plain object variable that merely
+        // happens to have a `value` key for a variable definition.
+        const isDefinition = entry
+            && typeof entry === 'object'
+            && !Array.isArray(entry)
+            && 'value' in entry
+            && ('type' in entry || 'secret' in entry);
+        if (isDefinition) {
+            if (entry.secret === true || names.has(name)) values.push(entry.value);
+            continue;
+        }
+        if (names.has(name)) values.push(entry);
+    }
+    return values;
+};
+
+/**
+ * List the names of variables flagged secret in the editor shape.
+ * @param {object} variables
+ * @returns {string[]}
+ */
+const collectSecretVarNames = (variables) => {
+    if (!variables || typeof variables !== 'object') return [];
+    return Object.entries(variables)
+        .filter(([, entry]) => entry && typeof entry === 'object' && entry.secret === true)
+        .map(([name]) => name);
+};
+
+/**
+ * Replace the values of secret variables with the mask, preserving structure.
+ * Used before writing a taskSnapshot into execution history.
+ * @param {object} variables
+ * @returns {object}
+ */
+const maskSecretVariables = (variables) => {
+    if (!variables || typeof variables !== 'object') return variables;
+    const out = {};
+    for (const [name, entry] of Object.entries(variables)) {
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && entry.secret === true) {
+            out[name] = { ...entry, value: entry.value === '' || entry.value === undefined || entry.value === null ? entry.value : MASK };
+        } else {
+            out[name] = entry;
+        }
+    }
+    return out;
+};
+
+/**
+ * Create an array whose `push` redacts every entry as it is written.
+ *
+ * Used for the agent's log buffer so that all existing (and future) `logs.push`
+ * call sites are covered without each having to remember to redact.
+ *
+ * @param {{ redact: Function }} redactor
+ * @returns {string[]}
+ */
+const createRedactingLog = (redactor) => {
+    const logs = [];
+    if (!redactor || !redactor.hasSecrets) return logs;
+    const originalPush = logs.push.bind(logs);
+    Object.defineProperty(logs, 'push', {
+        value: (...entries) => originalPush(...entries.map((entry) => redactor.redact(entry))),
+        writable: true,
+        configurable: true,
+        enumerable: false
+    });
+    return logs;
+};
+
+module.exports = {
+    MASK,
+    MIN_SECRET_LENGTH,
+    createRedactor,
+    createRedactingLog,
+    collectSecretValues,
+    collectSecretVarNames,
+    maskSecretVariables
+};

--- a/server.js
+++ b/server.js
@@ -78,6 +78,12 @@ const { pushOutput } = require('./src/server/outputProviders');
 const { migrateStorageState } = require('./src/server/migrate-storage');
 const { concurrencyGate } = require('./src/server/execution-queue');
 const { validateUrl } = require('./url-utils');
+const {
+    createRedactor,
+    collectSecretValues,
+    collectSecretVarNames,
+    maskSecretVariables
+} = require('./redaction');
 
 const app = express();
 app.disable('x-powered-by');
@@ -223,14 +229,49 @@ const registerExecution = (req, res, baseMeta = {}) => {
     const start = Date.now();
     const requestId = 'exec_' + start + '_' + Math.floor(Math.random() * 1000);
     res.locals.executionId = requestId;
+
+    // Single choke point for secret redaction: everything that leaves an
+    // execution — the HTTP response, the stored history entry, the webhook
+    // payload and the output provider push — flows through here, for every
+    // mode (agent, scrape, headful).
+    //
+    // Built lazily because executeTaskById replaces req.body with the merged
+    // task *after* registering, so the secret variables are not known yet at
+    // registration time.
+    let cachedRedactor = null;
+    const getRedactor = () => {
+        if (cachedRedactor) return cachedRedactor;
+        const reqBody = req.body || {};
+        const snapshotVars = reqBody.taskSnapshot && reqBody.taskSnapshot.variables;
+        const secretVarNames = Array.from(new Set([
+            ...(Array.isArray(reqBody.secretVars) ? reqBody.secretVars.map(String) : []),
+            ...collectSecretVarNames(snapshotVars)
+        ]));
+        cachedRedactor = createRedactor([
+            ...collectSecretValues(snapshotVars, secretVarNames),
+            ...collectSecretValues(reqBody.taskVariables, secretVarNames),
+            ...collectSecretValues(reqBody.variables, secretVarNames)
+        ]);
+        return cachedRedactor;
+    };
+    res.locals.getRedactor = getRedactor;
+
     const originalJson = res.json.bind(res);
     res.json = (body) => {
-        res.locals.executionResult = body;
-        return originalJson(body);
+        const redactor = getRedactor();
+        const safeBody = redactor.hasSecrets() ? redactor.redact(body) : body;
+        res.locals.executionResult = safeBody;
+        return originalJson(safeBody);
     };
     res.on('finish', () => {
         const durationMs = Date.now() - start;
         const body = req.body || {};
+        const redactor = getRedactor();
+        // Never persist secret values into execution history.
+        let snapshot = body.taskSnapshot || null;
+        if (snapshot && snapshot.variables) {
+            snapshot = { ...snapshot, variables: maskSecretVariables(snapshot.variables) };
+        }
         const entry = {
             id: requestId,
             timestamp: start,
@@ -242,8 +283,8 @@ const registerExecution = (req, res, baseMeta = {}) => {
             mode: body.mode || baseMeta.mode || 'unknown',
             taskId: body.taskId || baseMeta.taskId || null,
             taskName: body.name || baseMeta.taskName || null,
-            url: body.url || req.query.url || null,
-            taskSnapshot: body.taskSnapshot || null,
+            url: redactor.hasSecrets() ? redactor.redact(body.url || req.query.url || null) : (body.url || req.query.url || null),
+            taskSnapshot: snapshot,
             result: res.locals.executionResult || null
         };
         appendExecution(entry).catch(err => console.error('Failed to append execution:', err));
@@ -348,6 +389,13 @@ const executeTaskById = async (req, res) => {
     }
     const runtimeVars = { ...taskVars, ...clientVars };
 
+    // Variable definitions carry the `secret` flag; runtimeVars is flat, so the
+    // names travel alongside it for the engine and the redactor.
+    const secretVars = Array.from(new Set([
+        ...collectSecretVarNames(task.variables),
+        ...(Array.isArray(req.body.secretVars) ? req.body.secretVars.map(String) : [])
+    ]));
+
     req.body = {
         ...req.body,
         ...task,
@@ -355,6 +403,7 @@ const executeTaskById = async (req, res) => {
         taskId: task.id,
         variables: runtimeVars,
         taskVariables: runtimeVars,
+        secretVars,
         actions: task.actions || [],
         mode: task.mode || 'agent',
         extractionScript: req.body.extractionScript || task.extractionScript

--- a/src/agent/figranite/action-handler.js
+++ b/src/agent/figranite/action-handler.js
@@ -101,6 +101,28 @@ const getLocationalCoords = async (page, selectorValue, lastMouse) => {
     return { x: targetX, y: targetY, box };
 };
 
+// Visually mask an element before a secret is typed into it, so the value is
+// never rendered into screenshots or the .webm recording. Pass a null selector
+// to mask whatever currently has focus (global typing). Best effort: if the
+// page navigates or the selector is invalid we simply skip it.
+const maskElementForCaptures = async (page, selector) => {
+    try {
+        await page.evaluate((sel) => {
+            const STYLE_ID = '__figranium_secret_mask__';
+            if (!document.getElementById(STYLE_ID)) {
+                const style = document.createElement('style');
+                style.id = STYLE_ID;
+                style.textContent = '[data-figranium-secret="1"]{-webkit-text-security:disc!important;color:transparent!important;caret-color:transparent!important;text-shadow:0 0 6px rgba(0,0,0,0.55)!important}';
+                (document.head || document.documentElement).appendChild(style);
+            }
+            const el = sel ? document.querySelector(sel) : document.activeElement;
+            if (el && el !== document.body) el.setAttribute('data-figranium-secret', '1');
+        }, selector || null);
+    } catch {
+        // ignore — masking must never break the run
+    }
+};
+
 const executeAction = async (act, context) => {
     const {
         page,
@@ -116,6 +138,9 @@ const executeAction = async (act, context) => {
         setStopRequested,
         pendingDownloads
     } = context;
+
+    const isSecretValue = context.isSecretValue || (() => false);
+    const markSecret = context.markSecret || (() => { });
 
     const {
         deadClicks,
@@ -250,9 +275,12 @@ const executeAction = async (act, context) => {
             const selectorValue = act.selector ? resolveMaybe(act.selector) : null;
             const valueText = resolveMaybe(act.value) || '';
             const typeMode = act.typeMode === 'append' ? 'append' : 'replace';
+            const typingSecret = options.redactCaptures !== false && isSecretValue(valueText);
 
             const typeIntoSelector = async () => {
                 if (!selectorValue) return;
+
+                if (typingSecret) await maskElementForCaptures(page, selectorValue);
 
                 if (randomizeClicks) {
                     const loc = await getLocationalCoords(page, selectorValue, context.lastMouse);
@@ -317,6 +345,7 @@ const executeAction = async (act, context) => {
                 await typeIntoSelector();
             } else {
                 logs.push(`[FIGRANITE] Typing (global): ${valueText}`);
+                if (typingSecret) await maskElementForCaptures(page, null);
                 if (humanTyping) {
                     await humanType(page, null, valueText, humanOptions);
                 } else {
@@ -541,6 +570,9 @@ const executeAction = async (act, context) => {
                 const resolved = resolveMaybe(act.value || '');
                 const parsed = parseValue(resolved);
                 runtimeVars[String(act.varName)] = parsed;
+                // Values captured at runtime (an OTP read off the page, a token
+                // from an API response) can be flagged sensitive on the action.
+                if (act.secret === true) markSecret(parsed, act.varName);
                 logs.push(`Set variable ${act.varName}`);
                 result = parsed;
             }
@@ -634,6 +666,9 @@ const executeAction = async (act, context) => {
                 body: JSON.stringify({
                     variables: runtimeVars,
                     taskVariables: runtimeVars,
+                    // Carry secrecy across the task boundary so the child run
+                    // redacts the same values.
+                    secretVars: Array.from(context.secretVars || []),
                     runSource: 'agent_block',
                     taskId
                 })

--- a/src/agent/figranite/index.js
+++ b/src/agent/figranite/index.js
@@ -4,6 +4,7 @@ const { selectUserAgent } = require('../../../user-agent-settings');
 const { safeFormatHTML } = require('../../../html-utils');
 const { validateUrl } = require('../../../url-utils');
 const { parseBooleanFlag, sanitizeRunId, toCsvString } = require('../../../common-utils');
+const { createRedactor, createRedactingLog, collectSecretValues } = require('../../../redaction');
 const { runExtractionScript } = require('../sandbox');
 const { cleanHtml } = require('../dom-utils');
 const { launchBrowser, createBrowserContext } = require('../browser');
@@ -48,6 +49,26 @@ async function runFigranite(data, options = {}) {
     const runtimeVars = { ...(data.taskVariables || data.variables || {}) };
     let lastBlockOutput = null;
     runtimeVars['block.output'] = lastBlockOutput;
+
+    // Secret variables keep their real values in runtimeVars (they have to be
+    // typed, sent as headers, etc.) but every outbound surface is redacted.
+    const secretVarNames = Array.isArray(data.secretVars) ? data.secretVars.map(String) : [];
+    const snapshotVars = data.taskSnapshot && data.taskSnapshot.variables;
+    const redactor = createRedactor([
+        ...collectSecretValues(snapshotVars, secretVarNames),
+        ...collectSecretValues(runtimeVars, secretVarNames)
+    ], {
+        onSkip: (msg) => console.warn(`[FIGRANITE] ${msg}`)
+    });
+    // Names carried into child tasks started by the `start` action.
+    const activeSecretVars = new Set([
+        ...secretVarNames,
+        ...(snapshotVars && typeof snapshotVars === 'object'
+            ? Object.entries(snapshotVars)
+                .filter(([, v]) => v && typeof v === 'object' && v.secret === true)
+                .map(([name]) => name)
+            : [])
+    ]);
 
     const setBlockOutput = (value) => {
         lastBlockOutput = value;
@@ -141,7 +162,8 @@ async function runFigranite(data, options = {}) {
         });
         browser = context.browser();
 
-        const logs = [];
+        // Redacts on write, so every logs.push call site is covered.
+        const logs = createRedactingLog(redactor);
         const downloads = [];
         const pendingDownloads = new Set();
         const newDownloadListeners = new Set();
@@ -266,7 +288,10 @@ async function runFigranite(data, options = {}) {
             idleMovements,
             overscroll,
             cursorGlide,
-            randomizeClicks
+            randomizeClicks,
+            // Mask secret values on screen before typing so they never land in
+            // screenshots or the recording. On unless explicitly disabled.
+            redactCaptures: data.redactCaptures !== false
         };
 
         let index = 0;
@@ -290,6 +315,16 @@ async function runFigranite(data, options = {}) {
             set lastMouse(val) { lastMouse = val; },
             setStopOutcome: (out) => { stopOutcome = out; },
             setStopRequested: (req) => { stopRequested = req; },
+            redactor,
+            secretVars: activeSecretVars,
+            markSecret: (value, name) => {
+                redactor.addSecret(value);
+                if (name) activeSecretVars.add(String(name));
+            },
+            isSecretValue: (value) => {
+                if (typeof value !== 'string' || !value) return false;
+                return redactor.redactString(value) !== value;
+            },
             pendingDownloads,
             waitForNewDownload: () => new Promise(res => {
                 newDownloadListeners.add(res);
@@ -611,14 +646,17 @@ async function runFigranite(data, options = {}) {
         const rawExtraction = extraction.result !== undefined ? extraction.result : (extraction.logs.length ? extraction.logs.join('\n') : undefined);
         const formattedExtraction = extractionFormat === 'csv' ? toCsvString(rawExtraction) : rawExtraction;
 
-        const outputData = {
+        // Redact the whole payload: a secret can reach the caller through the
+        // serialized DOM (cleanHtml keeps `value` attributes), through an
+        // extraction script's result, or through a URL that carries it.
+        const outputData = redactor.redact({
             final_url: page.url() || url || '',
             downloads: downloads.length > 0 ? downloads : undefined,
-            logs: logs || [],
+            logs: Array.from(logs || []),
             html: (extractionScript && !includeHtml) ? undefined : (typeof cleanedHtml === 'string' ? safeFormatHTML(cleanedHtml) : ''),
             data: formattedExtraction,
             screenshot_url: screenshotSuccess ? `/captures/${screenshotName}` : null
-        };
+        });
 
         const video = page.video();
         if (!options.handoffContext) {
@@ -661,6 +699,12 @@ async function runFigranite(data, options = {}) {
         try { await browser.close(); } catch { }
         return outputData;
     } catch (error) {
+        // Playwright errors quote the failing selector/value, so a templated
+        // secret can surface in the message and the stack.
+        if (redactor.hasSecrets() && error && typeof error.message === 'string') {
+            error.message = redactor.redactString(error.message);
+            if (typeof error.stack === 'string') error.stack = redactor.redactString(error.stack);
+        }
         console.error('[FIGRANITE] Engine Error:', error);
         try {
             if (context) await context.close();

--- a/src/components/editor/ActionConfigModal.tsx
+++ b/src/components/editor/ActionConfigModal.tsx
@@ -530,6 +530,16 @@ const ActionConfigModal: React.FC<ActionConfigModalProps> = ({
                             placeholder="ready"
                         />
                     ))}
+                    {field('Sensitivity', inputWrap(
+                        <select
+                            value={action.secret ? 'secret' : 'normal'}
+                            onChange={(e) => onUpdate(action.id, { secret: e.target.value === 'secret' }, true)}
+                            className="custom-select w-full bg-transparent border-none px-0 py-0 text-[11px] text-white"
+                        >
+                            <option value="normal">Normal</option>
+                            <option value="secret">Secret — redact from logs &amp; results</option>
+                        </select>
+                    ))}
                 </>}
 
                 {/* Merge */}

--- a/src/components/editor/TaskSettingsCabinet.tsx
+++ b/src/components/editor/TaskSettingsCabinet.tsx
@@ -43,6 +43,7 @@ const TaskSettingsCabinet: React.FC<TaskSettingsCabinetProps & {
         const [dbLoading, setDbLoading] = React.useState(false);
         const [tableLoading, setTableLoading] = React.useState(false);
         const [browseSupported, setBrowseSupported] = React.useState(true);
+        const [revealedVars, setRevealedVars] = React.useState<Record<string, boolean>>({});
 
         React.useEffect(() => {
             if (isOpen) {
@@ -137,10 +138,12 @@ const TaskSettingsCabinet: React.FC<TaskSettingsCabinetProps & {
 
         const rotateProxiesDisabled = proxyListLoaded && proxyList.length === 1 && proxyList[0]?.id === 'host';
 
-        const updateVariable = (oldName: string, name: string, type: VarType, value: any) => {
+        const updateVariable = (oldName: string, name: string, type: VarType, value: any, secret?: boolean) => {
             const nextVars = { ...currentTask.variables };
+            const previous = nextVars[oldName];
             if (oldName !== name) delete nextVars[oldName];
-            nextVars[name] = { type, value };
+            const isSecret = secret === undefined ? previous?.secret === true : secret;
+            nextVars[name] = isSecret ? { type, value, secret: true } : { type, value };
             onUpdateTask({ variables: nextVars });
         };
 
@@ -149,6 +152,17 @@ const TaskSettingsCabinet: React.FC<TaskSettingsCabinetProps & {
             delete nextVars[name];
             onUpdateTask({ variables: nextVars });
         };
+
+        const hasSecretVars = Object.values(currentTask.variables || {}).some((v) => v?.secret);
+
+        // Never render real secret values into the copyable API sample.
+        const variablesPayloadSample = JSON.stringify({
+            variables: Object.fromEntries(
+                Object.entries(currentTask.variables || {})
+                    .slice(0, 2)
+                    .map(([k, v]) => [k, v.secret ? '<your-secret-value>' : v.value])
+            )
+        }, null, 2);
 
         const addVariable = () => {
             const name = `var_${Object.keys(currentTask.variables || {}).length + 1}`;
@@ -321,15 +335,50 @@ const TaskSettingsCabinet: React.FC<TaskSettingsCabinetProps & {
                                                         <option value="false">False</option>
                                                     </select>
                                                 ) : (
-                                                    <input
-                                                        type={def.type === 'number' ? 'number' : 'text'}
-                                                        value={def.value}
-                                                        onChange={(e) => updateVariable(name, name, def.type, def.type === 'number' ? parseFloat(e.target.value) : e.target.value)}
-                                                        placeholder="Default Value"
-                                                        className="w-full bg-black/40 border border-white/5 rounded-xl px-3 py-2 text-xs text-white"
-                                                    />
+                                                    <div className="relative">
+                                                        <input
+                                                            type={def.type === 'number' ? 'number' : (def.secret && !revealedVars[name] ? 'password' : 'text')}
+                                                            value={def.value}
+                                                            onChange={(e) => updateVariable(name, name, def.type, def.type === 'number' ? parseFloat(e.target.value) : e.target.value)}
+                                                            placeholder="Default Value"
+                                                            autoComplete="off"
+                                                            spellCheck={false}
+                                                            className={`w-full bg-black/40 border border-white/5 rounded-xl px-3 py-2 text-xs text-white ${def.secret && def.type !== 'number' ? 'pr-10' : ''}`}
+                                                        />
+                                                        {def.secret && def.type !== 'number' && (
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => setRevealedVars((prev) => ({ ...prev, [name]: !prev[name] }))}
+                                                                className="absolute right-1 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-gray-500 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                                                                aria-label={revealedVars[name] ? 'Hide value' : 'Reveal value'}
+                                                                title={revealedVars[name] ? 'Hide value' : 'Reveal value'}
+                                                            >
+                                                                <MaterialIcon name={revealedVars[name] ? 'visibility_off' : 'visibility'} className="text-sm" />
+                                                            </button>
+                                                        )}
+                                                    </div>
                                                 )}
                                             </div>
+
+                                            <button
+                                                role="switch"
+                                                aria-checked={!!def.secret}
+                                                onClick={() => updateVariable(name, name, def.type, def.value, !def.secret)}
+                                                className="flex items-center gap-2 pl-1 text-left group focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50 rounded-lg"
+                                                title="Redact this value from logs, results, history and captures"
+                                            >
+                                                <div className={`w-8 h-4 rounded-full relative transition-colors flex-shrink-0 ${def.secret ? 'bg-white' : 'bg-white/10'}`}>
+                                                    <div className={`absolute top-1 w-2 h-2 rounded-full transition-all ${def.secret ? 'right-1 bg-black' : 'left-1 bg-white/20'}`} />
+                                                </div>
+                                                <span className={`text-[10px] font-bold uppercase tracking-wider transition-colors ${def.secret ? 'text-white' : 'text-gray-600 group-hover:text-gray-400'}`}>
+                                                    Secret
+                                                </span>
+                                                {def.secret && (
+                                                    <span className="text-[9px] text-gray-500 normal-case font-normal tracking-normal">
+                                                        redacted from logs, results &amp; history
+                                                    </span>
+                                                )}
+                                            </button>
                                         </div>
                                     ))}
                                     {Object.keys(currentTask.variables || {}).length === 0 && (
@@ -375,6 +424,29 @@ const TaskSettingsCabinet: React.FC<TaskSettingsCabinetProps & {
                                             </button>
                                         ))}
                                     </div>
+
+                                    {hasSecretVars && (
+                                        <button
+                                            role="switch"
+                                            aria-checked={currentTask.redactCaptures !== false}
+                                            onClick={() => onUpdateTask({ redactCaptures: currentTask.redactCaptures === false })}
+                                            className={`w-full flex items-center justify-between p-4 rounded-2xl border transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50 ${currentTask.redactCaptures !== false
+                                                ? 'bg-white/10 border-white/30 text-white'
+                                                : 'bg-white/5 border-white/5 text-gray-400 opacity-60 hover:opacity-100'
+                                                }`}
+                                        >
+                                            <div className="flex items-center gap-3 text-left">
+                                                <MaterialIcon name="password" className="text-sm opacity-70" />
+                                                <div>
+                                                    <span className="text-xs font-medium">Mask Secrets On Screen</span>
+                                                    <p className="text-[9px] text-gray-500 mt-0.5">Hide secret values as they are typed so they never appear in screenshots or recordings</p>
+                                                </div>
+                                            </div>
+                                            <div className={`w-8 h-4 rounded-full relative transition-colors flex-shrink-0 ${currentTask.redactCaptures !== false ? 'bg-white' : 'bg-white/10'}`}>
+                                                <div className={`absolute top-1 w-2 h-2 rounded-full transition-all ${currentTask.redactCaptures !== false ? 'right-1 bg-black' : 'left-1 bg-white/20'}`} />
+                                            </div>
+                                        </button>
+                                    )}
                                 </div>
 
                                 <div className="space-y-4">
@@ -480,23 +552,20 @@ const TaskSettingsCabinet: React.FC<TaskSettingsCabinetProps & {
                                         <p className="text-[10px] text-gray-500">You can override task variables in the request body:</p>
                                         <div className="relative group">
                                             <div className="bg-black/40 border border-white/5 rounded-xl p-4 pr-12 font-mono text-[10px] text-white/60">
-                                                <pre>{JSON.stringify({
-                                                    variables: Object.fromEntries(
-                                                        Object.entries(currentTask.variables || {}).slice(0, 2).map(([k, v]) => [k, v.value])
-                                                    )
-                                                }, null, 2)}</pre>
+                                                <pre>{variablesPayloadSample}</pre>
                                             </div>
                                             <CopyButton
-                                                text={JSON.stringify({
-                                                    variables: Object.fromEntries(
-                                                        Object.entries(currentTask.variables || {}).slice(0, 2).map(([k, v]) => [k, v.value])
-                                                    )
-                                                }, null, 2)}
+                                                text={variablesPayloadSample}
                                                 className="absolute right-2 top-2 p-2 rounded-lg bg-white/5 border border-white/10 text-white opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-all"
                                                 iconClassName="text-xs"
                                                 title="Copy Payload"
                                             />
                                         </div>
+                                        {hasSecretVars && (
+                                            <p className="text-[9px] text-gray-600">
+                                                Secret variables show a placeholder here — replace it with the real value when you call the API.
+                                            </p>
+                                        )}
                                     </div>
                                 </div>
                             </div>

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Task } from '../types';
+import { Task, Variable } from '../types';
 import { normalizeImportedTask, buildNewTask, parseBooleanFlag, ensureActionIds } from '../utils/taskUtils';
 
 export function useTasks(
@@ -119,9 +119,28 @@ export function useTasks(
             return;
         }
 
+        // Export files get shared — never write secret values into one. The
+        // flag and the variable are kept so the importer only has to refill it.
+        let strippedSecrets = 0;
+        const sanitized = tasksToExport.map((task) => {
+            if (!task.variables) return task;
+            const entries = Object.entries(task.variables);
+            if (!entries.some(([, v]) => v?.secret)) return task;
+            const variables: Record<string, Variable> = {};
+            for (const [name, v] of entries) {
+                if (v?.secret) {
+                    if (v.value !== '' && v.value !== undefined && v.value !== null) strippedSecrets += 1;
+                    variables[name] = { ...v, value: '' };
+                } else {
+                    variables[name] = v;
+                }
+            }
+            return { ...task, variables };
+        });
+
         const payload = {
             exportedAt: new Date().toISOString(),
-            tasks: tasksToExport
+            tasks: sanitized
         };
         const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
@@ -133,7 +152,12 @@ export function useTasks(
         link.click();
         link.remove();
         URL.revokeObjectURL(url);
-        showAlert(`Exported ${tasksToExport.length} task(s).`, 'success');
+        showAlert(
+            strippedSecrets > 0
+                ? `Exported ${tasksToExport.length} task(s). ${strippedSecrets} secret value(s) left blank — refill them after importing.`
+                : `Exported ${tasksToExport.length} task(s).`,
+            'success'
+        );
     }, [tasks, showAlert]);
 
     const importTasks = useCallback(async (file: File) => {

--- a/src/server/scheduler.js
+++ b/src/server/scheduler.js
@@ -8,6 +8,7 @@ const { loadTasks, saveTasks, getTaskById } = require('./storage');
 const { appendExecution } = require('./storage');
 const { getNextRun, scheduleToCron, isValidCron } = require('./cron-parser');
 const { sendExecutionUpdate } = require('./state');
+const { createRedactor, collectSecretValues, collectSecretVarNames } = require('../../redaction');
 
 // Internal state
 let schedulerTimer = null;
@@ -174,6 +175,14 @@ async function tick(taskId) {
                 entry.taskName = task.name;
                 entry.mode = task.mode || 'agent';
                 entry.url = task.url || null;
+
+                // Scheduled runs bypass registerExecution, so redact here before
+                // the result reaches execution history.
+                const redactor = createRedactor(collectSecretValues(task.variables));
+                if (redactor.hasSecrets()) {
+                    entry.result = redactor.redact(entry.result);
+                    entry.url = redactor.redact(entry.url);
+                }
             }
         } catch { }
 
@@ -212,6 +221,8 @@ async function executeScheduledTask(taskId) {
         taskId: task.id,
         variables: runtimeVars,
         taskVariables: runtimeVars,
+        // runtimeVars is flat, so the `secret` flags travel separately.
+        secretVars: collectSecretVarNames(task.variables),
         actions: task.actions || [],
         mode: task.mode || 'agent',
         runSource: 'scheduler'

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,14 @@ export interface Variable {
     type: VarType;
     value: any;
     autoCreated?: boolean;
+    /**
+     * Marks the variable as sensitive (passwords, tokens, card numbers).
+     * The real value is still used during execution, but every occurrence of it
+     * is replaced with [REDACTED] in logs, results, API responses, webhooks and
+     * execution history, and it is masked on screen before being typed so it
+     * never reaches screenshots or recordings.
+     */
+    secret?: boolean;
 }
 
 export interface StealthConfig {
@@ -75,6 +83,8 @@ export interface Action {
     conditionOp?: string;
     conditionValue?: string;
     typeMode?: 'append' | 'replace';
+    /** `set` only — flag the captured value as sensitive for the rest of the run. */
+    secret?: boolean;
     method?: string;
     headers?: string;
     body?: string;
@@ -129,6 +139,8 @@ export interface Task {
     includeHtml?: boolean;
     output?: TaskOutput;
     includeShadowDom?: boolean;
+    /** Mask secret values on screen before typing (default true). */
+    redactCaptures?: boolean;
     disableRecording?: boolean;
     statelessExecution?: boolean;
     versions?: TaskVersion[];

--- a/tests/redaction.test.js
+++ b/tests/redaction.test.js
@@ -1,0 +1,197 @@
+// Tests for sensitive-variable redaction.
+// Run: node tests/redaction.test.js   (exit 0 = pass, 1 = fail)
+
+const assert = require('assert');
+const {
+    MASK,
+    MIN_SECRET_LENGTH,
+    createRedactor,
+    createRedactingLog,
+    collectSecretValues,
+    collectSecretVarNames,
+    maskSecretVariables
+} = require('../redaction');
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+
+test('redacts a secret inside a log line', () => {
+    const r = createRedactor(['hunter2pass']);
+    assert.strictEqual(
+        r.redactString('[FIGRANITE] Typing into #pw: hunter2pass'),
+        `[FIGRANITE] Typing into #pw: ${MASK}`
+    );
+});
+
+test('redacts every occurrence, not just the first', () => {
+    const r = createRedactor(['s3cr3t-token']);
+    const out = r.redactString('a s3cr3t-token b s3cr3t-token c');
+    assert.strictEqual(out, `a ${MASK} b ${MASK} c`);
+});
+
+test('redacts nested objects and arrays', () => {
+    const r = createRedactor(['p@ssw0rd']);
+    const out = r.redact({
+        logs: ['typed p@ssw0rd', 'ok'],
+        result: { nested: { deep: ['p@ssw0rd'] }, count: 2 },
+        html: '<input value="p@ssw0rd">'
+    });
+    assert.deepStrictEqual(out.logs, [`typed ${MASK}`, 'ok']);
+    assert.deepStrictEqual(out.result.nested.deep, [MASK]);
+    assert.strictEqual(out.result.count, 2);
+    assert.strictEqual(out.html, `<input value="${MASK}">`);
+});
+
+test('redacts object keys as well as values', () => {
+    const r = createRedactor(['leakyKeyName']);
+    const out = r.redact({ leakyKeyName: 'value' });
+    assert.deepStrictEqual(Object.keys(out), [MASK]);
+});
+
+test('leaves non-string primitives intact', () => {
+    const r = createRedactor(['abcdef']);
+    const out = r.redact({ n: 42, b: true, z: null, u: undefined });
+    assert.strictEqual(out.n, 42);
+    assert.strictEqual(out.b, true);
+    assert.strictEqual(out.z, null);
+    assert.strictEqual(out.u, undefined);
+});
+
+test('longer secrets win over overlapping shorter ones', () => {
+    // If the short secret were applied first it would leave "-extra" exposed.
+    const r = createRedactor(['token', 'token-extra-long']);
+    assert.strictEqual(r.redactString('value=token-extra-long'), `value=${MASK}`);
+});
+
+test('values shorter than the minimum are ignored', () => {
+    const skips = [];
+    const r = createRedactor(['ab'], { onSkip: (m) => skips.push(m) });
+    assert.strictEqual(r.hasSecrets(), false);
+    assert.strictEqual(r.redactString('ab cab tab'), 'ab cab tab');
+    assert.strictEqual(skips.length, 1);
+    assert.ok(String(MIN_SECRET_LENGTH).length > 0);
+});
+
+test('no secrets means output passes through untouched', () => {
+    const r = createRedactor([]);
+    const input = { a: 'anything at all' };
+    assert.strictEqual(r.redact(input), input);
+    assert.strictEqual(r.hasSecrets(), false);
+});
+
+test('handles cyclic objects without hanging', () => {
+    const r = createRedactor(['secretvalue']);
+    const cyclic = { name: 'secretvalue' };
+    cyclic.self = cyclic;
+    const out = r.redact(cyclic);
+    assert.strictEqual(out.name, MASK);
+});
+
+test('leaves non-plain objects (Date, Buffer) alone', () => {
+    const r = createRedactor(['secretvalue']);
+    const date = new Date();
+    const out = r.redact({ when: date });
+    assert.strictEqual(out.when, date);
+});
+
+test('addSecret extends coverage at runtime', () => {
+    const r = createRedactor([]);
+    assert.strictEqual(r.redactString('otp 998877'), 'otp 998877');
+    r.addSecret('998877');
+    assert.strictEqual(r.redactString('otp 998877'), `otp ${MASK}`);
+});
+
+test('numeric secret values are stringified', () => {
+    const r = createRedactor([123456]);
+    assert.strictEqual(r.redactString('pin=123456'), `pin=${MASK}`);
+});
+
+test('createRedactingLog redacts on push', () => {
+    const r = createRedactor(['mypassword']);
+    const logs = createRedactingLog(r);
+    logs.push('Typing into #pw: mypassword');
+    logs.push('unrelated');
+    assert.deepStrictEqual(logs, [`Typing into #pw: ${MASK}`, 'unrelated']);
+    assert.strictEqual(logs.length, 2);
+    assert.ok(Array.isArray(logs));
+});
+
+test('createRedactingLog supports multiple entries per push', () => {
+    const r = createRedactor(['mypassword']);
+    const logs = createRedactingLog(r);
+    logs.push('a mypassword', 'b mypassword');
+    assert.deepStrictEqual(logs, [`a ${MASK}`, `b ${MASK}`]);
+});
+
+test('collectSecretValues reads the editor variable shape', () => {
+    const values = collectSecretValues({
+        user: { type: 'string', value: 'ada' },
+        pass: { type: 'string', value: 'topsecret', secret: true }
+    });
+    assert.deepStrictEqual(values, ['topsecret']);
+});
+
+test('collectSecretValues reads the flattened shape via names', () => {
+    const values = collectSecretValues({ user: 'ada', pass: 'topsecret' }, ['pass']);
+    assert.deepStrictEqual(values, ['topsecret']);
+});
+
+test('collectSecretValues tolerates missing input', () => {
+    assert.deepStrictEqual(collectSecretValues(null), []);
+    assert.deepStrictEqual(collectSecretValues(undefined, ['x']), []);
+});
+
+test('collectSecretVarNames lists flagged names only', () => {
+    const names = collectSecretVarNames({
+        user: { type: 'string', value: 'ada' },
+        pass: { type: 'string', value: 'x', secret: true },
+        token: { type: 'string', value: 'y', secret: true }
+    });
+    assert.deepStrictEqual(names.sort(), ['pass', 'token']);
+});
+
+test('maskSecretVariables masks values but preserves structure', () => {
+    const masked = maskSecretVariables({
+        user: { type: 'string', value: 'ada' },
+        pass: { type: 'string', value: 'topsecret', secret: true }
+    });
+    assert.strictEqual(masked.user.value, 'ada');
+    assert.strictEqual(masked.pass.value, MASK);
+    assert.strictEqual(masked.pass.secret, true);
+    assert.strictEqual(masked.pass.type, 'string');
+});
+
+test('maskSecretVariables leaves empty secrets empty', () => {
+    const masked = maskSecretVariables({ pass: { type: 'string', value: '', secret: true } });
+    assert.strictEqual(masked.pass.value, '');
+});
+
+test('a secret derived into another variable is still redacted', () => {
+    // The `set` action copies a secret into a new variable; substring matching
+    // means the copy is covered without extra bookkeeping.
+    const r = createRedactor(['derived-secret-value']);
+    const out = r.redact({ copied: 'derived-secret-value', note: 'prefix derived-secret-value suffix' });
+    assert.strictEqual(out.copied, MASK);
+    assert.strictEqual(out.note, `prefix ${MASK} suffix`);
+});
+
+test('regex metacharacters in a secret are escaped', () => {
+    const r = createRedactor(['a+b.*c?']);
+    assert.strictEqual(r.redactString('value a+b.*c? here'), `value ${MASK} here`);
+    assert.strictEqual(r.redactString('value aXbYYcZ here'), 'value aXbYYcZ here');
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+    try {
+        fn();
+        console.log(`  PASS  ${name}`);
+    } catch (err) {
+        failed += 1;
+        console.error(`  FAIL  ${name}`);
+        console.error(`        ${err.message}`);
+    }
+}
+
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
…ptures

Task variables can now be flagged `secret: true` (Vars tab, or in the task JSON). The real value is still used at runtime - typed into forms, sent as headers, templated with {$name} - but every surface that leaves a run is redacted, implementing the open "Session recording redaction" roadmap item.

Previously a password variable leaked through at least eight paths: the "Typing into #pw: <value>" log line, the returned logs/html/data (cleanHtml preserves `value` attributes), the taskSnapshot persisted into execution history, webhook payloads, Baserow pushes, the entire runtimeVars map handed to child tasks by the `start` action, screenshots and .webm recordings, and task export files.

New redaction.js (root CJS, shared by server.js, the scheduler and the agent) builds one combined regex from the run's secret values, sorted longest-first so overlapping secrets cannot leave a remainder exposed, and deep-walks strings/arrays/objects. Cycles are guarded with a WeakSet, non-plain objects (Date, Buffer) pass through untouched, and a run with no secrets returns its input by identity so normal tasks pay nothing.

Coverage:
- Agent log buffer redacts on push, covering all existing call sites and any added later, plus the final output payload and thrown Playwright errors.
- registerExecution is a single choke point wrapping res.json, so the HTTP response, stored execution entry, webhook and output-provider push are all covered for agent, scrape and headful alike; taskSnapshot variable values are masked before persisting.
- Scheduled runs bypass registerExecution entirely, so the scheduler redacts its own execution entry and forwards secret variable names to the engine.
- Fields are visually masked before keystrokes are sent, so plaintext never renders into a screenshot or recording. Per-task redactCaptures toggle, on by default.
- The `start` action forwards secret names across the task boundary.
- Task export blanks secret values while keeping the flag, so a shared export file carries no credentials.

Matching is on the exact value, which also covers derived values: copying a secret into another variable or embedding it in a larger string still matches. Values under 4 characters are skipped with a warning rather than matching nearly every log line. Secret values remain plaintext at rest in data/tasks.json, as Baserow credential tokens already are; documented in SECURITY.md.

Adds tests/redaction.test.js (22 cases). Verified: npm run build clean (tsc + vite), 22/22 redaction tests, npm test, and 20 existing suites pass. sentinel_security.test.js and persistent_session.test.js fail identically on untouched main and are unrelated (the former requires the pre-figranite path src/agent/action-handler).