### PR TITLE
Update task export filename to use figranium-tasks prefix

### DIFF
--- a/src/components/fleet/FleetScreen.tsx
+++ b/src/components/fleet/FleetScreen.tsx
@@ -5,7 +5,7 @@ import TaskMatrixTab from './tabs/TaskMatrixTab';
 import VariableTablesTab from './tabs/VariableTablesTab';
 import SchedulesDropsTab from './tabs/SchedulesDropsTab';
 import InfrastructureTab from './tabs/InfrastructureTab';
-import { FleetTab, FleetRowStatus, FleetWorkerState, FleetSignal, ProxyPreset } from '../../types';
+import { FleetTab, FleetWorkerState, ProxyPreset } from '../../types';
 
 interface FleetScreenProps {
     onNotify: (message: string, tone?: 'success' | 'error') => void;
@@ -13,11 +13,10 @@ interface FleetScreenProps {
 
 const FleetScreen: React.FC<FleetScreenProps> = ({ onNotify }) => {
     const [activeTab, setActiveTab] = useState<FleetTab>('matrix');
-    const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+    const [selectedTaskId] = useState<string | null>(null);
     const [workers, setWorkers] = useState<FleetWorkerState[]>([]);
     const [rows, setRows] = useState<any[]>([]);
     const [proxies, setProxies] = useState<ProxyPreset[]>([]);
-    const [signals, setSignals] = useState<FleetSignal[]>([]);
     const [fleetConfig, setFleetConfig] = useState<any>(null);
     const [loading, setLoading] = useState(true);
 
@@ -34,7 +33,8 @@ const FleetScreen: React.FC<FleetScreenProps> = ({ onNotify }) => {
             setWorkers(workersRes.workers || []);
             setRows(rowsRes.rows || []);
             setProxies(proxiesRes.proxies || []);
-            setSignals(signalsRes.signals || []);
+            // Signals data is fetched but unused in the UI
+            void signalsRes;
             setFleetConfig(configRes.config || null);
         } catch (e: any) {
             onNotify(`Failed to load fleet data: ${e.message}`, 'error');
@@ -48,7 +48,8 @@ const FleetScreen: React.FC<FleetScreenProps> = ({ onNotify }) => {
         const interval = setInterval(() => {
             // Poll for live updates of workers and signals
             fetch('/api/fleet/workers', { credentials: 'include' }).then(r => r.json()).then(d => setWorkers(d.workers || [])).catch(() => {});
-            fetch('/api/fleet/signals', { credentials: 'include' }).then(r => r.json()).then(d => setSignals(d.signals || [])).catch(() => {});
+            // Signals data is fetched but unused in the UI
+            fetch('/api/fleet/signals', { credentials: 'include' }).then(() => {}).catch(() => {});
         }, 2000);
         return () => clearInterval(interval);
     }, [loadFleetData]);

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -128,7 +128,7 @@ export function useTasks(
         const link = document.createElement('a');
         const stamp = new Date().toISOString().slice(0, 10);
         link.href = url;
-        link.download = `doppelganger-tasks-${stamp}.json`;
+        link.download = `figranium-tasks-${stamp}.json`;
         document.body.appendChild(link);
         link.click();
         link.remove();

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,3 +188,29 @@ export interface ConfirmRequest {
     cancelLabel?: string;
     title?: string;
 }
+
+export type FleetTab = 'matrix' | 'variables' | 'schedules' | 'infrastructure';
+
+export type FleetRowStatus = 'IDLE' | 'RUNNING' | 'SUCCESS' | 'FAILED' | string;
+
+export interface FleetWorkerState {
+    id: string;
+    activeActionId?: string;
+    status: 'IDLE' | 'RUNNING' | 'SUCCESS' | 'FAILED' | string;
+    rowIndex?: number;
+    startTime?: number;
+    proxy?: string;
+}
+
+export interface FleetSignal {
+    id: string;
+    [key: string]: any;
+}
+
+export interface ProxyPreset {
+    id: string;
+    name: string;
+    proxies?: string[];
+    rotationMode?: string;
+    stickyBinding?: boolean;
+}


### PR DESCRIPTION
This change updates the prefix of exported task filenames to `figranium-tasks` instead of `doppelganger-tasks` inside `src/hooks/useTasks.ts`. In addition, it registers the missing types for the Fleet Management module (`FleetTab`, `FleetRowStatus`, `FleetWorkerState`, `FleetSignal`, `ProxyPreset`) in `src/types.ts` and cleans up unused TS definitions in `src/components/fleet/FleetScreen.tsx` to fix project build failures and ensure a clean, warning-free bundle compile step.

---
*PR created automatically by Jules for task [9544326629692154891](https://jules.google.com/task/9544326629692154891) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved fleet status handling during initial loading and ongoing updates for a cleaner, more reliable experience.
  * Added support for richer fleet worker states, task statuses, scheduling views, infrastructure information, and proxy configuration metadata.

* **Bug Fixes**
  * Exported task files now use the `figranium-tasks` filename prefix for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->