### PR TITLE
Fix local loopback WebSocket disconnects and HeadfulModal status loading

### DIFF
--- a/src/components/editor/HeadfulModal.tsx
+++ b/src/components/editor/HeadfulModal.tsx
@@ -85,8 +85,13 @@ const HeadfulModal: React.FC<HeadfulModalProps> = ({
                     </div>
                 </div>
                 <div ref={headfulFrameRef} className="w-full aspect-video relative bg-black flex items-center justify-center">
-                    {useNovnc === false ? (
-                        <div className="text-center p-8">
+                    {useNovnc === null ? (
+                        <div className="text-center p-8 flex flex-col items-center justify-center gap-3">
+                            <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+                            <p className="text-white/60 text-xs tracking-wider uppercase">Checking browser status...</p>
+                        </div>
+                    ) : useNovnc === false ? (
+                        <div className="text-center p-8 animate-in fade-in duration-300">
                             <MaterialIcon name="open_in_new" className="text-6xl text-white/20 mb-4 block" />
                             <h3 className="text-white text-lg font-bold mb-2">Browser Opened Natively</h3>
                             <p className="text-white/60 text-sm max-w-md mx-auto leading-relaxed mb-6">
@@ -97,7 +102,7 @@ const HeadfulModal: React.FC<HeadfulModalProps> = ({
                     ) : (
                         <iframe
                             src={headfulUrl}
-                            className="absolute inset-0 w-full h-full border-0"
+                            className="absolute inset-0 w-full h-full border-0 animate-in fade-in duration-300"
                             title="Headful Browser"
                         />
                     )}

--- a/url-utils.js
+++ b/url-utils.js
@@ -329,8 +329,36 @@ async function setupNavigationProtection(context) {
 function isValidWebSocketOrigin(origin, host) {
     if (!origin) return true;
     try {
-        const originHost = new URL(origin).host;
-        return !!(originHost && host && originHost === host);
+        const originUrl = new URL(origin);
+        const originHost = originUrl.host;
+        if (originHost && host && originHost === host) {
+            return true;
+        }
+
+        const originHostname = originUrl.hostname.toLowerCase();
+
+        let hostHostname = host.toLowerCase();
+        if (hostHostname.includes('[')) {
+            const closeBracket = hostHostname.indexOf(']');
+            if (closeBracket !== -1) {
+                hostHostname = hostHostname.slice(1, closeBracket);
+            }
+        } else {
+            const colonIndex = hostHostname.indexOf(':');
+            if (colonIndex !== -1) {
+                hostHostname = hostHostname.slice(0, colonIndex);
+            }
+        }
+
+        const isExactLocal = (h) => {
+            return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+        };
+
+        if (isExactLocal(originHostname) && isExactLocal(hostHostname)) {
+            return true;
+        }
+
+        return false;
     } catch (e) {
         return false;
     }


### PR DESCRIPTION
This change addresses the local loopback WebSocket upgrade issues when running the browser or inspect tools on Mac (or other local hosts).

1. WebSocket Connection Fix: Modified `isValidWebSocketOrigin` in `url-utils.js` to allow loopback and local development hosts (`localhost`, `127.0.0.1`, `::1`) even with different ports, resolving blocks from Cross-Site WebSocket Hijacking (CSWSH) protection.
2. Improved UI State Handling: Updated `HeadfulModal.tsx` to display a spinner during status check of `useNovnc` before attempting VNC frame loading, avoiding transient 'Connecting...' -> 'Disconnected' flashes when running natively.

---
*PR created automatically by Jules for task [16867251205438567788](https://jules.google.com/task/16867251205438567788) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading state while browser status is being determined.
  * Added smooth fade-in transitions for native browser and embedded viewing modes.

* **Bug Fixes**
  * Improved WebSocket origin validation for IPv6 addresses and equivalent local hosts.
  * Invalid origins continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->