### PR TITLE
Support Session and API Key Auth for Browser & Inspector Tools

### DIFF
--- a/src/server/routes/browser.js
+++ b/src/server/routes/browser.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireApiKey } = require('../middleware');
+const { requireAuthOrApiKey } = require('../middleware');
 const { launchApiSession, getActiveSession, ensureSessionId } = require('../../../headful');
 
 const router = express.Router();
@@ -155,7 +155,7 @@ async function buildSelectorResults(page, elements) {
  * Body: { url, mode? ('headful'), devTools? }
  * Returns: { sessionId, status, wsEndpoint }
  */
-router.post('/browser/open', requireApiKey, async (req, res) => {
+router.post('/browser/open', requireAuthOrApiKey, async (req, res) => {
     try {
         const { url, mode = 'headful', devTools = false } = req.body || {};
         // mode is currently informational — only headful is supported via VNC stack
@@ -196,7 +196,7 @@ router.post('/browser/open', requireApiKey, async (req, res) => {
  * Body: { sessionId?, url?, targetHint? }
  * Returns: { success, selectors: [{css, xpath, confidence}], snapshot? }
  */
-router.post('/inspector/highlight', requireApiKey, async (req, res) => {
+router.post('/inspector/highlight', requireAuthOrApiKey, async (req, res) => {
     try {
         const { sessionId, url, targetHint } = req.body || {};
         let session = getActiveSession();


### PR DESCRIPTION
Updated /api/browser/open and /api/inspector/highlight endpoints to use the requireAuthOrApiKey middleware instead of requireApiKey. This allows session-authenticated users in the UI dashboard and API-key-authenticated clients like Model Context Protocol (MCP) servers to seamlessly launch and interact with these browser tools.

---
*PR created automatically by Jules for task [11082617342607477450](https://jules.google.com/task/11082617342607477450) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser and inspector routes now support authenticated access in addition to API key authentication.
  * Browser session launching and inspector behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->