### PR TITLE
fix(vnc): bind websockify to IPv4 loopback explicitly to avoid IPv6 m…

### DIFF
--- a/server.js
+++ b/server.js
@@ -207,6 +207,7 @@ app.use('/api/data', dataRoutes);
 app.use('/api/schedules', scheduleRoutes);
 app.use('/api/credentials', credentialRoutes);
 app.use('/api/health', healthRoutes);
+app.use('/api', browserRoutes);
 
 // View Routes & Static
 app.use('/', viewRoutes);

--- a/src/components/editor/HeadfulModal.tsx
+++ b/src/components/editor/HeadfulModal.tsx
@@ -85,8 +85,13 @@ const HeadfulModal: React.FC<HeadfulModalProps> = ({
                     </div>
                 </div>
                 <div ref={headfulFrameRef} className="w-full aspect-video relative bg-black flex items-center justify-center">
-                    {useNovnc === false ? (
-                        <div className="text-center p-8">
+                    {useNovnc === null ? (
+                        <div className="text-center p-8 flex flex-col items-center justify-center gap-3">
+                            <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+                            <p className="text-white/60 text-xs tracking-wider uppercase">Checking browser status...</p>
+                        </div>
+                    ) : useNovnc === false ? (
+                        <div className="text-center p-8 animate-in fade-in duration-300">
                             <MaterialIcon name="open_in_new" className="text-6xl text-white/20 mb-4 block" />
                             <h3 className="text-white text-lg font-bold mb-2">Browser Opened Natively</h3>
                             <p className="text-white/60 text-sm max-w-md mx-auto leading-relaxed mb-6">
@@ -97,7 +102,7 @@ const HeadfulModal: React.FC<HeadfulModalProps> = ({
                     ) : (
                         <iframe
                             src={headfulUrl}
-                            className="absolute inset-0 w-full h-full border-0"
+                            className="absolute inset-0 w-full h-full border-0 animate-in fade-in duration-300"
                             title="Headful Browser"
                         />
                     )}

--- a/url-utils.js
+++ b/url-utils.js
@@ -329,8 +329,41 @@ async function setupNavigationProtection(context) {
 function isValidWebSocketOrigin(origin, host) {
     if (!origin) return true;
     try {
-        const originHost = new URL(origin).host;
-        return !!(originHost && host && originHost === host);
+        const originUrl = new URL(origin);
+        const originHost = originUrl.host;
+        if (originHost && host && originHost === host) {
+            return true;
+        }
+
+        const originHostname = originUrl.hostname.toLowerCase();
+
+        let hostHostname = host.toLowerCase();
+        if (hostHostname.includes('[')) {
+            const closeBracket = hostHostname.indexOf(']');
+            if (closeBracket !== -1) {
+                hostHostname = hostHostname.slice(1, closeBracket);
+            }
+        } else {
+            const colonIndex = hostHostname.indexOf(':');
+            if (colonIndex !== -1) {
+                hostHostname = hostHostname.slice(0, colonIndex);
+            }
+        }
+
+        // Helper to check if a hostname is loopback or local/private
+        const isLocalOrPrivate = (h) => {
+            if (h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === 'host.docker.internal' || h.endsWith('.local')) {
+                return true;
+            }
+            // Check if it's a private IP address
+            return isPrivateIP(h);
+        };
+
+        if (isLocalOrPrivate(originHostname) && isLocalOrPrivate(hostHostname)) {
+            return true;
+        }
+
+        return false;
     } catch (e) {
         return false;
     }


### PR DESCRIPTION
…ismatches inside Docker on Mac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-related API routes under the `/api` path.
  * Improved support for local, private-network, Docker-local, and IPv6 browser connections.

* **Bug Fixes**
  * Enhanced browser-origin validation while continuing to reject invalid connections.

* **UI Improvements**
  * Added a loading indicator and status message while browser access is being checked.
  * Added smooth fade-in transitions for browser fallback and embedded views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->