### PR TITLE
Support Multi-Arch Playwright Browser Installation in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,14 @@ ENV FIGRANIUM_SKIP_PLAYWRIGHT_INSTALL=1 \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN npm ci --omit=dev
 
+ARG TARGETARCH
 # Ensure Playwright browsers + OS deps are available
-RUN npx playwright install --with-deps chromium chrome firefox webkit
+RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then \
+        npx playwright install --with-deps chromium firefox webkit; \
+    else \
+        npx playwright install --with-deps chromium chrome firefox webkit; \
+    fi
 
 # Copy server and built assets
 COPY --from=build /app/dist /app/dist


### PR DESCRIPTION
Fixed a CI build error on ARM64 architecture during Docker multi-platform builds. Playwright's browser installer doesn't support Google Chrome on Linux ARM64, resulting in a build crash. This PR resolves it by conditionally installing Playwright browsers depending on `TARGETARCH` with a fallback to `dpkg --print-architecture`. It skips the branded Chrome installation on ARM64 while retaining it on AMD64.

---
*PR created automatically by Jules for task [488550256761688310](https://jules.google.com/task/488550256761688310) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser installation for different processor architectures.
  * ARM64 environments now install Chromium, Firefox, and WebKit; other architectures also include Chrome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->