### PR TITLE
Revert "Support Multi-Arch Playwright Browser Installation in Docker"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,8 @@ ENV FIGRANIUM_SKIP_PLAYWRIGHT_INSTALL=1 \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN npm ci --omit=dev
 
-ARG TARGETARCH
 # Ensure Playwright browsers + OS deps are available
-RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
-    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then \
-        npx playwright install --with-deps chromium firefox webkit; \
-    else \
-        npx playwright install --with-deps chromium chrome firefox webkit; \
-    fi
+RUN npx playwright install --with-deps chromium chrome firefox webkit
 
 # Copy server and built assets
 COPY --from=build /app/dist /app/dist


### PR DESCRIPTION
Reverts figranium/figranium#337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * The runtime environment now includes Chromium, Chrome, Firefox, and WebKit for broader browser compatibility.
  * Browser availability is consistent across supported runtime architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->