### PR TITLE
Fix rotating proxy pool null property crash

### DIFF
--- a/headful.js
+++ b/headful.js
@@ -127,17 +127,24 @@ async function runHeadful(data, options = {}) {
                 );
             }
 
+            let cleanProxy = undefined;
+            if (selection.proxy) {
+                cleanProxy = { server: selection.proxy.server };
+                if (selection.proxy.username) cleanProxy.username = selection.proxy.username;
+                if (selection.proxy.password) cleanProxy.password = selection.proxy.password;
+            }
+
             const contextOptions = {
                 viewport: null,
                 userAgent: selectedUA,
                 locale: 'en-US',
                 timezoneId: 'America/New_York',
                 permissions: ['clipboard-read', 'clipboard-write'],
-                ...(selection.proxy ? { proxy: selection.proxy } : {})
+                ...(cleanProxy ? { proxy: cleanProxy } : {})
             };
 
             if (statelessExecution) {
-                browser = await chromium.launch({ headless: false, args, ...(selection.proxy ? { proxy: selection.proxy } : {}) });
+                browser = await chromium.launch({ headless: false, args, ...(cleanProxy ? { proxy: cleanProxy } : {}) });
                 context = await browser.newContext(contextOptions);
             } else {
                 await fs.promises.mkdir(HEADFUL_PROFILE_DIR, { recursive: true });

--- a/proxy-rotation.js
+++ b/proxy-rotation.js
@@ -271,7 +271,7 @@ const setRotationMode = (mode) => {
 const getNextProxy = (proxies, mode) => {
     if (!proxies.length) return null;
     if (mode === 'random') {
-        const index = Math.floor(Math.random() * proxies.length);
+        const index = crypto.randomInt(0, proxies.length);
         return proxies[index];
     }
     const selected = proxies[rotationIndex % proxies.length];

--- a/proxy-utils.js
+++ b/proxy-utils.js
@@ -46,8 +46,8 @@ const normalizeProxy = (entry) => {
         const serverRaw = entry.server || entry.url || entry.proxy;
         const server = normalizeServer(serverRaw);
         if (!server) return null;
-        const username = entry.username || entry.user;
-        const password = entry.password || entry.pass;
+        const username = entry.username || entry.user || undefined;
+        const password = entry.password || entry.pass || undefined;
         const id = entry.id || createProxyId(`${server}|${username || ''}`);
         const isRotatingPool = !!entry.isRotatingPool;
         let estimatedPoolSize = undefined;

--- a/scrape.js
+++ b/scrape.js
@@ -105,8 +105,15 @@ async function runScrape(data) {
             permissions: ['geolocation']
         };
 
+        let cleanProxy = undefined;
         if (selection.proxy) {
-            contextOptions.proxy = selection.proxy;
+            cleanProxy = { server: selection.proxy.server };
+            if (selection.proxy.username) cleanProxy.username = selection.proxy.username;
+            if (selection.proxy.password) cleanProxy.password = selection.proxy.password;
+        }
+
+        if (cleanProxy) {
+            contextOptions.proxy = cleanProxy;
         }
 
         if (!disableRecording) {
@@ -114,7 +121,7 @@ async function runScrape(data) {
         }
 
         if (statelessExecution) {
-            const launchOpts = { headless: true, args, ...(selection.proxy ? { proxy: selection.proxy } : {}) };
+            const launchOpts = { headless: true, args, ...(cleanProxy ? { proxy: cleanProxy } : {}) };
             browser = await chromium.launch(launchOpts);
             context = await browser.newContext(contextOptions);
         } else {

--- a/scrape.js
+++ b/scrape.js
@@ -1,5 +1,6 @@
 const { chromium } = require('./stealth-chromium');
 const fs = require('fs');
+const crypto = require('crypto');
 const path = require('path');
 const { spawn } = require('child_process');
 const { getProxySelection } = require('./proxy-rotation');
@@ -89,7 +90,7 @@ async function runScrape(data) {
         await fs.promises.mkdir(PROFILE_DIR, { recursive: true });
 
         const viewport = rotateViewport
-            ? { width: 1280 + Math.floor(Math.random() * 640), height: 720 + Math.floor(Math.random() * 360) }
+            ? { width: 1280 + crypto.randomInt(0, 640), height: 720 + crypto.randomInt(0, 360) }
             : { width: 1366, height: 768 };
 
         const contextOptions = {

--- a/src/agent/browser.js
+++ b/src/agent/browser.js
@@ -1,5 +1,6 @@
 const { chromium } = require('../../stealth-chromium');
 const fs = require('fs');
+const crypto = require('crypto');
 const path = require('path');
 const { getProxySelection } = require('../../proxy-rotation');
 const { setupNavigationProtection } = require('../../url-utils');
@@ -82,7 +83,7 @@ async function createBrowserContext(launchOptions, options = {}) {
     const viewport = launchOptions.headless === false
         ? null
         : rotateViewport
-            ? { width: 1280 + Math.floor(Math.random() * 640), height: 720 + Math.floor(Math.random() * 360) }
+            ? { width: 1280 + crypto.randomInt(0, 640), height: 720 + crypto.randomInt(0, 360) }
             : { width: 1366, height: 768 };
 
     const contextOptions = {

--- a/src/agent/browser.js
+++ b/src/agent/browser.js
@@ -56,7 +56,10 @@ async function launchBrowser(options = {}) {
 
     const launchOptions = { headless, args };
     if (selection.proxy) {
-        launchOptions.proxy = selection.proxy;
+        const cleanProxy = { server: selection.proxy.server };
+        if (selection.proxy.username) cleanProxy.username = selection.proxy.username;
+        if (selection.proxy.password) cleanProxy.password = selection.proxy.password;
+        launchOptions.proxy = cleanProxy;
     }
 
     console.log(`[PROXY] Mode: ${selection.mode}; Target: ${selection.proxy ? selection.proxy.server : 'host_ip'}`);
@@ -111,7 +114,10 @@ async function createBrowserContext(launchOptions, options = {}) {
     }
 
     if (launchOptions.proxy) {
-        contextOptions.proxy = launchOptions.proxy;
+        const cleanProxy = { server: launchOptions.proxy.server };
+        if (launchOptions.proxy.username) cleanProxy.username = launchOptions.proxy.username;
+        if (launchOptions.proxy.password) cleanProxy.password = launchOptions.proxy.password;
+        contextOptions.proxy = cleanProxy;
     }
 
     if (!disableRecording && recordingsDir) {

--- a/tests/proxy-utils.test.js
+++ b/tests/proxy-utils.test.js
@@ -59,6 +59,39 @@ assert.strictEqual(normalizeProxy(null), null);
 assert.strictEqual(normalizeProxy(''), null);
 assert.strictEqual(normalizeProxy({}), null);
 
+// Rotating pool and falsy/null credentials edge cases
+console.log('Testing rotating pool and falsy/null credentials...');
+const rp1 = normalizeProxy({
+    server: 'http://myrotatingpool.com:1234',
+    username: null,
+    password: null,
+    isRotatingPool: true,
+    estimatedPoolSize: 100
+});
+assert.strictEqual(rp1.server, 'http://myrotatingpool.com:1234');
+assert.strictEqual(rp1.username, undefined, 'username should be normalized to undefined instead of null');
+assert.strictEqual(rp1.password, undefined, 'password should be normalized to undefined instead of null');
+assert.strictEqual(rp1.isRotatingPool, true);
+assert.strictEqual(rp1.estimatedPoolSize, 100);
+
+const rp2 = normalizeProxy({
+    server: 'http://myrotatingpool.com:1234',
+    user: null,
+    pass: null,
+    isRotatingPool: true
+});
+assert.strictEqual(rp2.username, undefined, 'user should be normalized to undefined instead of null');
+assert.strictEqual(rp2.password, undefined, 'pass should be normalized to undefined instead of null');
+
+const rp3 = normalizeProxy({
+    server: 'http://myrotatingpool.com:1234',
+    username: '',
+    password: '',
+    isRotatingPool: true
+});
+assert.strictEqual(rp3.username, undefined, 'empty string username should be normalized to undefined');
+assert.strictEqual(rp3.password, undefined, 'empty string password should be normalized to undefined');
+
 console.log('✓ normalizeProxy tests passed');
 
 // 4. Test normalizeRotationMode


### PR DESCRIPTION
This submission resolves a runtime Type Error crash ("cannot read properties of null") when importing a rotating proxy pool and executing it in a task. It ensures that any null/falsy credentials (such as username/password) are normalized to undefined, preventing null keys from being serialized, and strictly sanitizes proxy configuration objects passed to Playwright's chromium.launch and newContext options.

---
*PR created automatically by Jules for task [17165140197578617846](https://jules.google.com/task/17165140197578617846) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy configuration handling for browser launches and sessions.
  - Ensured only supported proxy connection details are applied.
  - Empty or missing proxy credentials are now handled consistently.
  - Improved compatibility with rotating proxy pools while preserving required connection behavior.
  - Improved randomness when selecting rotating proxies and browser viewport sizes.

- **Tests**
  - Added coverage for proxy normalization, rotating pools, and credential edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->