### PR TITLE
Fix browser tools (open and highlight) on Mac

### DIFF
--- a/headful.js
+++ b/headful.js
@@ -112,13 +112,13 @@ async function runHeadful(data, options = {}) {
                 '--no-sandbox',
                 '--disable-setuid-sandbox',
                 '--disable-dev-shm-usage',
-                '--disable-gpu',
                 '--window-size=1920,1080',
-                '--window-position=0,0',
-                '--start-maximized',
                 '--dns-prefetch-disable',
                 '--force-webrtc-ip-handling-policy=disable_non_proxied_udp'
             ];
+            if (process.platform !== 'darwin') {
+                args.push('--disable-gpu', '--window-position=0,0', '--start-maximized');
+            }
             if (!hasProxy) {
                 args.push(
                     '--enable-features=DnsOverHttps',
@@ -143,8 +143,10 @@ async function runHeadful(data, options = {}) {
                 ...(cleanProxy ? { proxy: cleanProxy } : {})
             };
 
+            const isHeadless = parseBooleanFlag(data.headless) || parseBooleanFlag(process.env.HEADLESS);
+
             if (statelessExecution) {
-                browser = await chromium.launch({ headless: false, args, ...(cleanProxy ? { proxy: cleanProxy } : {}) });
+                browser = await chromium.launch({ headless: isHeadless, args, ...(cleanProxy ? { proxy: cleanProxy } : {}) });
                 context = await browser.newContext(contextOptions);
             } else {
                 await fs.promises.mkdir(HEADFUL_PROFILE_DIR, { recursive: true });
@@ -152,7 +154,7 @@ async function runHeadful(data, options = {}) {
                 for (const lockFile of ['SingletonLock', 'SingletonCookie', 'SingletonSocket']) {
                     try { await fs.promises.unlink(path.join(HEADFUL_PROFILE_DIR, lockFile)); } catch { }
                 }
-                context = await chromium.launchPersistentContext(HEADFUL_PROFILE_DIR, { headless: false, args, ...contextOptions });
+                context = await chromium.launchPersistentContext(HEADFUL_PROFILE_DIR, { headless: isHeadless, args, ...contextOptions });
                 browser = context.browser();
             }
         }
@@ -459,11 +461,13 @@ async function runHeadful(data, options = {}) {
             // Persistent context auto-creates a blank page; reuse it or open a new one
             const existingPages = context.pages();
             page = existingPages.length > 0 ? existingPages[0] : await context.newPage();
-            try {
-                const cdp = await context.newCDPSession(page);
-                const { windowId } = await cdp.send('Browser.getWindowForTarget');
-                await cdp.send('Browser.setWindowBounds', { windowId, bounds: { windowState: 'maximized' } });
-            } catch (e) { }
+            if (process.platform !== 'darwin') {
+                try {
+                    const cdp = await context.newCDPSession(page);
+                    const { windowId } = await cdp.send('Browser.getWindowForTarget');
+                    await cdp.send('Browser.setWindowBounds', { windowId, bounds: { windowState: 'maximized' } });
+                } catch (e) { }
+            }
         } else {
             try { await page.evaluate(inspectInitFn); } catch (e) { }
             try {
@@ -536,6 +540,18 @@ async function runHeadful(data, options = {}) {
     }
 }
 
+function isDisplayUnavailableError(err) {
+    const message = String(err && err.message ? err.message : err).toLowerCase();
+    return message.includes('missing x server')
+        || message.includes('$display')
+        || message.includes('platform failed to initialize')
+        || message.includes('no display server')
+        || message.includes('target page, context or browser has been closed')
+        || message.includes('target closed')
+        || message.includes('x11 connection failed')
+        || message.includes('cannot open display');
+}
+
 async function handleHeadful(req, res) {
     await headfulMutex.lock();
     try {
@@ -543,8 +559,7 @@ async function handleHeadful(req, res) {
         await runHeadful(data, { res });
     } catch (error) {
         const message = String(error && error.message ? error.message : error);
-        const displayUnavailable = /missing x server|\$display|platform failed to initialize/i.test(message);
-        if (!res.headersSent && displayUnavailable) {
+        if (!res.headersSent && isDisplayUnavailableError(message)) {
             return res.status(409).json({ error: 'HEADFUL_DISPLAY_UNAVAILABLE', details: message });
         }
         if (!res.headersSent) {
@@ -605,27 +620,44 @@ async function launchApiSession(data = {}) {
         }
         return activeSession;
     }
-    // Use the same headless:false flow managed by handleHeadful, but without a res object
-    // so it doesn't auto-respond. We trigger it asynchronously and then poll for the
-    // session to transition to 'running'.
-    const fakeReq = { body: data, query: {} };
-    const fakeRes = { headersSent: true, json: () => {}, status: () => fakeRes };
-    // Fire-and-forget; runHeadful resolves on browser disconnect which we intentionally
-    // do not await here.
-    runHeadful(data, { res: fakeRes }).catch((e) => {
-        console.error('[HEADFUL] launchApiSession error:', e && e.message ? e.message : e);
-    });
 
-    // Poll until activeSession becomes 'running' or timeout
+    const fakeRes = { headersSent: true, json: () => {}, status: () => fakeRes };
+    let launchError = null;
+
+    const startSession = (sessionData) => {
+        runHeadful(sessionData, { res: fakeRes }).catch((e) => {
+            launchError = e;
+            console.error('[HEADFUL] launchApiSession error:', e && e.message ? e.message : e);
+        });
+    };
+
+    startSession(data);
+
+    // Poll until activeSession becomes 'running' or error occurs
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
         if (activeSession && activeSession.status === 'running') return activeSession;
-        if (!activeSession) {
-            await new Promise(r => setTimeout(r, 200));
-            continue;
-        }
-        await new Promise(r => setTimeout(r, 200));
+        if (launchError) break;
+        await new Promise(r => setTimeout(r, 100));
     }
+
+    // If initial launch failed due to display unavailable, automatically retry in headless mode
+    if (launchError && isDisplayUnavailableError(launchError)) {
+        console.log('[HEADFUL] Display unavailable during API browser launch. Retrying in headless mode...');
+        launchError = null;
+        startSession({ ...data, headless: true });
+        const fallbackDeadline = Date.now() + 30000;
+        while (Date.now() < fallbackDeadline) {
+            if (activeSession && activeSession.status === 'running') return activeSession;
+            if (launchError) break;
+            await new Promise(r => setTimeout(r, 100));
+        }
+    }
+
+    if (launchError) {
+        throw launchError;
+    }
+
     return activeSession;
 }
 

--- a/src/server/routes/browser.js
+++ b/src/server/routes/browser.js
@@ -59,107 +59,136 @@ async function getXPathForElement(page, elementHandle) {
 }
 
 /**
- * Find candidate elements for a targetHint. Strategy:
- *  1. If targetHint looks like a CSS selector (starts with #, ., [ or contains >, :, space-simple), try querySelector.
- *  2. Otherwise, search by visible text, name/placeholder/aria-label attributes.
- * Returns up to 5 unique elements.
+ * Find candidate elements for a targetHint and generate selectors + XPaths in page context.
  */
-async function findCandidateElements(page, targetHint) {
-    return await page.evaluate((hint) => {
-        const results = [];
-        const seen = new Set();
-        const push = (el) => {
-            if (el && !seen.has(el) && results.length < 5) {
-                seen.add(el);
-                results.push(el);
+async function inspectTargetInPage(page, targetHint) {
+    if (!page || !targetHint) return [];
+    try {
+        return await page.evaluate((hint) => {
+            const results = [];
+            const seen = new Set();
+            const push = (el) => {
+                if (el && !seen.has(el) && results.length < 5) {
+                    seen.add(el);
+                    results.push(el);
+                }
+            };
+            const trimmed = (hint || '').trim();
+            if (!trimmed) return [];
+
+            // 1) Try as CSS selector
+            try {
+                const matches = document.querySelectorAll(trimmed);
+                matches.forEach(push);
+            } catch (e) { /* not a valid selector, fall through */ }
+
+            // 2) Attribute-based matching (name, placeholder, aria-label, title, alt, value)
+            if (results.length < 5) {
+                const attrNames = ['name', 'placeholder', 'aria-label', 'title', 'alt', 'value', 'data-testid', 'data-test-id'];
+                for (const attr of attrNames) {
+                    if (results.length >= 5) break;
+                    try {
+                        document.querySelectorAll(`[${attr}="${trimmed.replace(/"/g, '\\"')}"]`).forEach(push);
+                    } catch (e) {}
+                }
             }
-        };
-        const trimmed = (hint || '').trim();
-        if (!trimmed) return [];
 
-        // 1) Try as CSS selector
-        try {
-            const matches = document.querySelectorAll(trimmed);
-            matches.forEach(push);
-        } catch (e) { /* not a valid selector, fall through */ }
-
-        // 2) Attribute-based matching (name, placeholder, aria-label, title, alt, value)
-        if (results.length < 5) {
-            const attrNames = ['name', 'placeholder', 'aria-label', 'title', 'alt', 'value', 'data-testid', 'data-test-id'];
-            for (const attr of attrNames) {
-                if (results.length >= 5) break;
-                try {
-                    document.querySelectorAll(`[${attr}="${trimmed.replace(/"/g, '\\"')}"]`).forEach(push);
-                } catch (e) {}
-            }
-        }
-
-        // 3) Text content matching (buttons, links, labels, headings)
-        if (results.length < 5) {
-            const textTags = ['button', 'a', 'label', 'span', 'div', 'h1', 'h2', 'h3', 'h4', 'li', 'p'];
-            const lowerHint = trimmed.toLowerCase();
-            for (const tag of textTags) {
-                if (results.length >= 5) break;
-                const els = Array.from(document.querySelectorAll(tag));
-                for (const el of els) {
-                    const text = (el.textContent || '').trim().toLowerCase();
-                    if (text && (text === lowerHint || text.includes(lowerHint))) {
-                        push(el);
-                        if (results.length >= 5) break;
+            // 3) Text content matching (buttons, links, labels, headings)
+            if (results.length < 5) {
+                const textTags = ['button', 'a', 'label', 'span', 'div', 'h1', 'h2', 'h3', 'h4', 'li', 'p'];
+                const lowerHint = trimmed.toLowerCase();
+                for (const tag of textTags) {
+                    if (results.length >= 5) break;
+                    const els = Array.from(document.querySelectorAll(tag));
+                    for (const el of els) {
+                        const text = (el.textContent || '').trim().toLowerCase();
+                        if (text && (text === lowerHint || text.includes(lowerHint))) {
+                            push(el);
+                            if (results.length >= 5) break;
+                        }
                     }
                 }
             }
-        }
 
-        return results;
-    }, targetHint);
-}
+            if (results.length === 0) return [];
 
-/**
- * Compute selectors + xpath + confidence for each candidate element.
- */
-async function buildSelectorResults(page, elements) {
-    // Get CSS selectors using existing in-page helper
-    const cssLists = await Promise.all(elements.map(async (el) => {
-        try {
-            return await page.evaluate((node) => {
-                if (window._figraniumGetSelectors) {
-                    return window._figraniumGetSelectors(node);
+            // Visually highlight the top match via overlay rectangle
+            try {
+                const topEl = results[0];
+                const overlayId = 'figranium-api-highlight';
+                let overlay = document.getElementById(overlayId);
+                if (!overlay) {
+                    overlay = document.createElement('div');
+                    overlay.id = overlayId;
+                    overlay.style.position = 'fixed';
+                    overlay.style.pointerEvents = 'none';
+                    overlay.style.zIndex = '2147483646';
+                    overlay.style.backgroundColor = 'rgba(59, 130, 246, 0.15)';
+                    overlay.style.border = '2px solid rgb(96, 165, 250)';
+                    overlay.style.boxSizing = 'border-box';
+                    document.body.appendChild(overlay);
                 }
-                // fallback: tag name only
-                return [node.tagName ? node.tagName.toLowerCase() : ''];
-            }, el);
-        } catch (e) {
-            return [];
-        }
-    }));
+                const rect = topEl.getBoundingClientRect();
+                overlay.style.top = rect.top + 'px';
+                overlay.style.left = rect.left + 'px';
+                overlay.style.width = rect.width + 'px';
+                overlay.style.height = rect.height + 'px';
+                overlay.style.display = 'block';
+                topEl.scrollIntoView({ block: 'center', inline: 'center' });
+            } catch (e) {}
 
-    const xpaths = await Promise.all(elements.map((el) => getXPathForElement(page, el)));
+            // Compute XPath for an element
+            function getElementXPath(el) {
+                if (!el || el.nodeType !== 1) return '';
+                if (el.id) return `//*[@id="${el.id}"]`;
+                const parts = [];
+                while (el && el.nodeType === 1) {
+                    let index = 1;
+                    let sibling = el.previousElementSibling;
+                    while (sibling) {
+                        if (sibling.tagName === el.tagName) index++;
+                        sibling = sibling.previousElementSibling;
+                    }
+                    parts.unshift(`${el.tagName.toLowerCase()}[${index}]`);
+                    el = el.parentElement;
+                }
+                return '/' + parts.join('/');
+            }
 
-    const results = [];
-    for (let i = 0; i < elements.length; i++) {
-        const cssList = cssLists[i] || [];
-        const css = cssList[0] || '';
-        const xpath = xpaths[i] || '';
-        if (!css && !xpath) continue;
-        // Confidence heuristic: first CSS selector gets highest score; drop as we fall back
-        const base = 0.98 - (i * 0.05);
-        results.push({ css, xpath, confidence: Math.max(0.5, base) });
+            // Generate selectors for each candidate element
+            const selectorResults = [];
+            for (let i = 0; i < results.length; i++) {
+                const el = results[i];
+                let cssList = [];
+                if (window._figraniumGetSelectors) {
+                    cssList = window._figraniumGetSelectors(el);
+                } else if (el.tagName) {
+                    cssList = [el.tagName.toLowerCase()];
+                }
+                const css = cssList[0] || '';
+                const xpath = getElementXPath(el);
+                if (!css && !xpath) continue;
+                const base = 0.98 - (i * 0.05);
+                selectorResults.push({ css, xpath, confidence: Math.max(0.5, base) });
+            }
+
+            return selectorResults;
+        }, targetHint);
+    } catch (e) {
+        return [];
     }
-    return results;
 }
 
 /**
  * POST /api/browser/open
  * Launch (or reattach) a managed browser session.
- * Body: { url, mode? ('headful'), devTools? }
+ * Body: { url, mode? ('headful'), devTools?, headless? }
  * Returns: { sessionId, status, wsEndpoint }
  */
 router.post('/browser/open', requireAuthOrApiKey, async (req, res) => {
     try {
-        const { url, mode = 'headful', devTools = false } = req.body || {};
-        // mode is currently informational — only headful is supported via VNC stack
-        const session = await launchApiSession({ url });
+        const { url, mode = 'headful', devTools = false, headless } = req.body || {};
+        const session = await launchApiSession({ url, mode, devTools, headless });
         if (!session || session.status !== 'running') {
             return res.status(409).json({ error: 'BROWSER_LAUNCH_FAILED', details: 'Session did not reach running state.' });
         }
@@ -181,7 +210,7 @@ router.post('/browser/open', requireAuthOrApiKey, async (req, res) => {
         res.json({ sessionId, status: 'launched', wsEndpoint });
     } catch (e) {
         const message = String(e && e.message ? e.message : e);
-        const displayUnavailable = /missing x server|\$display|platform failed to initialize/i.test(message);
+        const displayUnavailable = /missing x server|\$display|platform failed to initialize|target page, context or browser has been closed|target closed|no display server|x11 connection failed|cannot open display/i.test(message);
         if (displayUnavailable) {
             return res.status(409).json({ error: 'HEADFUL_DISPLAY_UNAVAILABLE', details: message });
         }
@@ -238,36 +267,7 @@ router.post('/inspector/highlight', requireAuthOrApiKey, async (req, res) => {
 
         let selectors = [];
         if (targetHint) {
-            const candidates = await findCandidateElements(page, targetHint);
-            selectors = await buildSelectorResults(page, candidates);
-
-            // Visually highlight the top match via overlay rectangle
-            if (candidates.length > 0) {
-                try {
-                    await page.evaluate((el) => {
-                        const overlayId = 'figranium-api-highlight';
-                        let overlay = document.getElementById(overlayId);
-                        if (!overlay) {
-                            overlay = document.createElement('div');
-                            overlay.id = overlayId;
-                            overlay.style.position = 'fixed';
-                            overlay.style.pointerEvents = 'none';
-                            overlay.style.zIndex = '2147483646';
-                            overlay.style.backgroundColor = 'rgba(59, 130, 246, 0.15)';
-                            overlay.style.border = '2px solid rgb(96, 165, 250)';
-                            overlay.style.boxSizing = 'border-box';
-                            document.body.appendChild(overlay);
-                        }
-                        const rect = el.getBoundingClientRect();
-                        overlay.style.top = rect.top + 'px';
-                        overlay.style.left = rect.left + 'px';
-                        overlay.style.width = rect.width + 'px';
-                        overlay.style.height = rect.height + 'px';
-                        overlay.style.display = 'block';
-                        el.scrollIntoView({ block: 'center', inline: 'center' });
-                    }, candidates[0]);
-                } catch (e) {}
-            }
+            selectors = await inspectTargetInPage(page, targetHint);
         }
 
         // Optional snapshot (small, JPEG to keep size down)

--- a/src/server/routes/browser.js
+++ b/src/server/routes/browser.js
@@ -85,10 +85,11 @@ async function inspectTargetInPage(page, targetHint) {
             // 2) Attribute-based matching (name, placeholder, aria-label, title, alt, value)
             if (results.length < 5) {
                 const attrNames = ['name', 'placeholder', 'aria-label', 'title', 'alt', 'value', 'data-testid', 'data-test-id'];
+                const safeAttrVal = trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
                 for (const attr of attrNames) {
                     if (results.length >= 5) break;
                     try {
-                        document.querySelectorAll(`[${attr}="${trimmed.replace(/"/g, '\\"')}"]`).forEach(push);
+                        document.querySelectorAll(`[${attr}="${safeAttrVal}"]`).forEach(push);
                     } catch (e) {}
                 }
             }

--- a/src/utils/executionUtils.ts
+++ b/src/utils/executionUtils.ts
@@ -28,5 +28,9 @@ export const isDisplayUnavailable = (message: string) => {
     return lower.includes('missing x server')
         || lower.includes('$display')
         || lower.includes('platform failed to initialize')
-        || lower.includes('no display server');
+        || lower.includes('no display server')
+        || lower.includes('target page, context or browser has been closed')
+        || lower.includes('target closed')
+        || lower.includes('x11 connection failed')
+        || lower.includes('cannot open display');
 };


### PR DESCRIPTION
Fix browser tools ('open' and 'highlight') on macOS and non-X11 environments by omitting unsupported Chromium flags/CDP window calls on darwin, implementing automatic headless fallback on display launch errors, and eliminating DOM node serialization issues during element inspection.

---
*PR created automatically by Jules for task [35198803319237687](https://jules.google.com/task/35198803319237687) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for launching browsers in headless mode through request settings or environment configuration.
  - Browser opening now respects display, developer tools, and launch mode preferences.
  - Improved in-page inspection with more accurate element matching, selector generation, confidence scoring, and visual highlighting.

- **Bug Fixes**
  - Improved compatibility on macOS by avoiding unsupported window and GPU handling.
  - Expanded detection of display, X11, and closed-browser failures.
  - Added automatic headless retry when a graphical display is unavailable.
  - Browser launch failures are now reported promptly instead of delaying requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->