### PR TITLE
Remove [FIGRANITE] prefix from activity log in web UI

### DIFF
--- a/src/agent/browser.js
+++ b/src/agent/browser.js
@@ -17,10 +17,10 @@ async function injectHeadfulCookies(context) {
         const cookies = (state.cookies || []).filter(c => !c.expires || c.expires === -1 || c.expires > now);
         if (cookies.length > 0) {
             await context.addCookies(cookies);
-            console.log(`[FIGRANITE] Injected ${cookies.length} cookies from headful session`);
+            console.log(`Injected ${cookies.length} cookies from headful session`);
         }
     } catch (e) {
-        if (e.code !== 'ENOENT') console.error('[FIGRANITE] Failed to inject headful cookies:', e.message);
+        if (e.code !== 'ENOENT') console.error('Failed to inject headful cookies:', e.message);
     }
 }
 
@@ -106,10 +106,10 @@ async function createBrowserContext(launchOptions, options = {}) {
                 const exists = await fs.promises.access(sessionPath).then(() => true).catch(() => false);
                 if (exists) {
                     contextOptions.storageState = sessionPath;
-                    console.log(`[FIGRANITE] Loading persistent session from ${cleanSessionId}.json`);
+                    console.log(`Loading persistent session from ${cleanSessionId}.json`);
                 }
             } catch (e) {
-                console.error('[FIGRANITE] Failed to load session path:', e.message);
+                console.error('Failed to load session path:', e.message);
             }
         }
     }

--- a/src/agent/figranite/action-handler.js
+++ b/src/agent/figranite/action-handler.js
@@ -144,7 +144,7 @@ const executeAction = async (act, context) => {
             } catch (e) {
                 throw new Error(`Access to private network is restricted`);
             }
-            logs.push(`[FIGRANITE] Navigating to: ${targetUrl}`);
+            logs.push(`Navigating to: ${targetUrl}`);
             await page.goto(targetUrl, { waitUntil: 'domcontentloaded' });
             result = page.url();
             break;
@@ -152,7 +152,7 @@ const executeAction = async (act, context) => {
         case 'click': {
             const selectorValue = resolveMaybe(act.selector);
             const coords = parseCoords(String(selectorValue || ''));
-            logs.push(`[FIGRANITE] Clicking: ${selectorValue}`);
+            logs.push(`Clicking: ${selectorValue}`);
             if (coords) {
                 await moveMouseHumanlike(page, coords.x, coords.y, { cursorGlide, startX: context.lastMouse?.x, startY: context.lastMouse?.y });
                 await page.mouse.click(coords.x, coords.y, { delay: baseDelay(50) });
@@ -169,7 +169,7 @@ const executeAction = async (act, context) => {
 
             // Neutral Dead Click
             if (deadClicks && Math.random() < 0.4) {
-                logs.push('[FIGRANITE] Performing neutral dead-click...');
+                logs.push('Performing neutral dead-click...');
                 const viewport = page.viewportSize() || { width: 1280, height: 720 };
                 const dcX = 10 + Math.random() * (viewport.width * 0.2);
                 const dcY = 10 + Math.random() * (viewport.height * 0.2);
@@ -222,7 +222,7 @@ const executeAction = async (act, context) => {
                     }
 
                     if (clickMissed) {
-                        logs.push('[FIGRANITE] Click may have missed, falling back to Playwright click.');
+                        logs.push('Click may have missed, falling back to Playwright click.');
                         await page.click(selectorValue, { delay: baseDelay(50) });
                     }
                     // Update lastMouse after center click
@@ -304,7 +304,7 @@ const executeAction = async (act, context) => {
 
             if (selectorValue) {
                 const coords = parseCoords(String(selectorValue));
-                logs.push(`[FIGRANITE] Typing into ${selectorValue}: ${valueText}`);
+                logs.push(`Typing into ${selectorValue}: ${valueText}`);
                 if (coords) {
                     await moveMouseHumanlike(page, coords.x, coords.y, { cursorGlide, startX: context.lastMouse?.x, startY: context.lastMouse?.y });
                     await page.mouse.click(coords.x, coords.y, { delay: baseDelay(50) });
@@ -316,7 +316,7 @@ const executeAction = async (act, context) => {
                 await page.waitForSelector(selectorValue, { timeout: actionTimeout });
                 await typeIntoSelector();
             } else {
-                logs.push(`[FIGRANITE] Typing (global): ${valueText}`);
+                logs.push(`Typing (global): ${valueText}`);
                 if (humanTyping) {
                     await humanType(page, null, valueText, humanOptions);
                 } else {
@@ -329,7 +329,7 @@ const executeAction = async (act, context) => {
         case 'hover': {
             const selectorValue = resolveMaybe(act.selector);
             const coords = parseCoords(String(selectorValue || ''));
-            logs.push(`[FIGRANITE] Hovering: ${selectorValue}`);
+            logs.push(`Hovering: ${selectorValue}`);
             if (coords) {
                 await moveMouseHumanlike(page, coords.x, coords.y, { cursorGlide, startX: context.lastMouse?.x, startY: context.lastMouse?.y });
                 context.lastMouse = { x: coords.x, y: coords.y };

--- a/src/agent/figranite/index.js
+++ b/src/agent/figranite/index.js
@@ -516,7 +516,7 @@ async function runFigranite(data, options = {}) {
                 if (result !== undefined) setBlockOutput(result);
                 reportProgress(runId, { actionId: act.id, status: 'success' });
             } catch (err) {
-                logs.push(`[FIGRANITE] FAILED action ${act.type}: ${err.message}`);
+                logs.push(`FAILED action ${act.type}: ${err.message}`);
                 reportProgress(runId, { actionId: act.id, status: 'error' });
                 if (errorHandler && !inErrorHandler) {
                     inErrorHandler = true;
@@ -535,7 +535,7 @@ async function runFigranite(data, options = {}) {
         await page.waitForTimeout(baseDelay(500));
 
         if (pendingDownloads.size > 0) {
-            logs.push(`[FIGRANITE] Waiting for ${pendingDownloads.size} pending download(s)...`);
+            logs.push(`Waiting for ${pendingDownloads.size} pending download(s)...`);
             try {
                 await Promise.race([
                     Promise.all(Array.from(pendingDownloads)),
@@ -619,10 +619,10 @@ async function runFigranite(data, options = {}) {
                 try {
                     await fs.promises.mkdir(path.dirname(sessionPath), { recursive: true });
                     await context.storageState({ path: sessionPath });
-                    logs.push(`[FIGRANITE] Saved persistent session state to ${cleanSessionId}.json`);
+                    logs.push(`Saved persistent session state to ${cleanSessionId}.json`);
                 } catch (e) {
-                    console.error('[FIGRANITE] Failed to save session path:', e.message);
-                    logs.push(`[FIGRANITE] Failed to save session state: ${e.message}`);
+                    console.error('Failed to save session path:', e.message);
+                    logs.push(`Failed to save session state: ${e.message}`);
                 }
             }
         }
@@ -677,7 +677,7 @@ async function runFigranite(data, options = {}) {
         try { await browser.close(); } catch { }
         return outputData;
     } catch (error) {
-        console.error('[FIGRANITE] Engine Error:', error);
+        console.error('Engine Error:', error);
         try {
             if (context) await context.close();
         } catch { }


### PR DESCRIPTION
Removed `[FIGRANITE]` prefix from activity log entries in `src/agent/figranite/index.js`, `src/agent/figranite/action-handler.js`, and `src/agent/browser.js` so that activity logs in the web UI display clean text.

---
*PR created automatically by Jules for task [17568113685796808136](https://jules.google.com/task/17568113685796808136) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified application log messages by removing the `[FIGRANITE]` prefix.
  * Updated navigation, interaction, session, download, and error messages for more consistent output.
  * No functional behavior or error handling was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->