### PR TITLE
Persist theme settings to backend data storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,31 @@
     <link
         href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
         rel="stylesheet" />
+    <script>
+        (function() {
+            try {
+                var theme = 'dark';
+                var cookies = document.cookie ? document.cookie.split(';') : [];
+                for (var i = 0; i < cookies.length; i++) {
+                    var c = cookies[i].trim();
+                    if (c.indexOf('figranium_theme=') === 0 || c.indexOf('theme=') === 0) {
+                        var val = c.substring(c.indexOf('=') + 1).trim();
+                        if (['dark', 'light', 'solarized-light', 'solarized-dark'].indexOf(val) !== -1) {
+                            theme = val;
+                            break;
+                        }
+                    }
+                }
+                if (theme === 'dark' && localStorage) {
+                    var local = localStorage.getItem('figranium.theme');
+                    if (local && ['dark', 'light', 'solarized-light', 'solarized-dark'].indexOf(local) !== -1) {
+                        theme = local;
+                    }
+                }
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {}
+        })();
+    </script>
 </head>
 
 <body class="bg-[#020202] text-gray-100 font-sans h-full overflow-hidden selection:bg-white selection:text-black">

--- a/server_output.log
+++ b/server_output.log
@@ -1,9 +1,10 @@
-[vnc] Starting Xvfb on :99
-[vnc] Starting x11vnc on :5900
-[vnc] Serving noVNC on 0.0.0.0:54311
-[vnc] Starting server
+
+> figranium@0.14.2 start
+> node server.js
+
 Server running at http://localhost:11345
 [SCHEDULER] Loaded 0 scheduled task(s).
-[PROXY] Mode: host; Target: host_ip
-[PROXY] Mode: host; Target: host_ip
-[PROXY] Mode: host; Target: host_ip
+Error: ENOENT: no such file or directory, stat '/app/dist/index.html'
+[SHUTDOWN] Received SIGTERM, shutting down gracefully...
+[SHUTDOWN] HTTP server closed.
+[SHUTDOWN] Cleanup complete.

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -4,9 +4,26 @@ import { THEMES, ThemeDefinition, ThemeId, DEFAULT_THEME_ID, getThemeById, apply
 const THEME_STORAGE_KEY = 'figranium.theme';
 const THEME_INTRO_KEY = 'figranium.seenThemeIntro';
 
+function setCookie(id: string) {
+    if (typeof document === 'undefined') return;
+    try {
+        document.cookie = `figranium_theme=${id}; path=/; max-age=31536000; SameSite=Lax`;
+    } catch {
+        // ignore
+    }
+}
+
 function getInitialTheme(): ThemeDefinition {
     if (typeof window === 'undefined') return getThemeById(DEFAULT_THEME_ID);
     try {
+        const cookies = document.cookie ? document.cookie.split(';') : [];
+        for (const raw of cookies) {
+            const c = raw.trim();
+            if (c.startsWith('figranium_theme=') || c.startsWith('theme=')) {
+                const val = c.substring(c.indexOf('=') + 1).trim();
+                if (val) return getThemeById(val);
+            }
+        }
         const stored = localStorage.getItem(THEME_STORAGE_KEY);
         return stored ? getThemeById(stored) : getThemeById(DEFAULT_THEME_ID);
     } catch {
@@ -20,12 +37,33 @@ export function useTheme() {
 
     useEffect(() => {
         applyThemeVars(theme);
+        setCookie(theme.id);
         try {
             localStorage.setItem(THEME_STORAGE_KEY, theme.id);
         } catch {
             // ignore
         }
     }, [theme]);
+
+    // Fetch persisted theme from backend data on mount and sync
+    useEffect(() => {
+        let mounted = true;
+        fetch('/api/settings/theme', { credentials: 'include' })
+            .then(res => res.ok ? res.json() : null)
+            .then(data => {
+                if (mounted && data && typeof data.theme === 'string') {
+                    const serverTheme = getThemeById(data.theme);
+                    setThemeState(serverTheme);
+                    applyThemeVars(serverTheme);
+                    setCookie(serverTheme.id);
+                    try {
+                        localStorage.setItem(THEME_STORAGE_KEY, serverTheme.id);
+                    } catch { }
+                }
+            })
+            .catch(() => { });
+        return () => { mounted = false; };
+    }, []);
 
     // Check whether to show the first-time popup
     useEffect(() => {
@@ -42,13 +80,23 @@ export function useTheme() {
     const setTheme = useCallback((id: ThemeId) => {
         const next = getThemeById(id);
         setThemeState(next);
-        // Immediately persist and apply so the switch is instant even before effect runs
+        // Immediately apply theme and set cookie/localStorage for fast UI feedback
+        applyThemeVars(next);
+        setCookie(next.id);
         try {
             localStorage.setItem(THEME_STORAGE_KEY, next.id);
         } catch {
             // ignore
         }
-        applyThemeVars(next);
+        // Persist theme to backend data storage
+        fetch('/api/settings/theme', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ theme: next.id })
+        }).catch(err => {
+            console.error('Failed to persist theme to backend data:', err);
+        });
     }, []);
 
     const dismissIntro = useCallback(() => {

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -16,6 +16,8 @@ const CLAUDE_API_KEY_FILE = path.join(DATA_DIR, 'claude_api_key.json');
 const OLLAMA_API_KEY_FILE = path.join(DATA_DIR, 'ollama_api_key.json');
 const AI_MODELS_FILE = path.join(DATA_DIR, 'ai_models.json');
 const DEFAULT_AI_MODELS = { gemini: 'gemini-3-flash-preview', openai: 'gpt-5-nano', claude: 'claude-haiku-4-6', ollama: 'llama3.2' };
+const THEME_FILE = path.join(DATA_DIR, 'theme.json');
+const DEFAULT_THEME_ID = 'dark';
 const STORAGE_STATE_PATH = path.join(__dirname, '../../storage_state.json');
 const EXECUTIONS_FILE = path.join(DATA_DIR, 'executions.json');
 const CREDENTIALS_FILE = path.join(DATA_DIR, 'credentials.json');
@@ -48,6 +50,8 @@ module.exports = {
     OLLAMA_API_KEY_FILE,
     AI_MODELS_FILE,
     DEFAULT_AI_MODELS,
+    THEME_FILE,
+    DEFAULT_THEME_ID,
     STORAGE_STATE_PATH,
     EXECUTIONS_FILE,
     CREDENTIALS_FILE,

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -58,6 +58,12 @@ async function initDB() {
                     );
                 `);
                 await client.query(`
+                    CREATE TABLE IF NOT EXISTS theme_config (
+                        id INT PRIMARY KEY DEFAULT 1,
+                        data JSONB NOT NULL
+                    );
+                `);
+                await client.query(`
                     CREATE TABLE IF NOT EXISTS tasks (
                         id VARCHAR(255) PRIMARY KEY,
                         data JSONB NOT NULL

--- a/src/server/routes/settings.js
+++ b/src/server/routes/settings.js
@@ -378,7 +378,7 @@ router.post('/ai-models', csrfProtection, dataRateLimiter, requireAuthForSetting
 });
 
 // Theme Persistence Endpoints
-router.get('/theme', requireAuthForSettings, async (req, res) => {
+router.get('/theme', dataRateLimiter, requireAuthForSettings, async (req, res) => {
     try {
         let theme = await loadThemeConfig();
         if (!theme) {

--- a/src/server/routes/settings.js
+++ b/src/server/routes/settings.js
@@ -8,8 +8,10 @@ const {
     loadOpenAiApiKey, saveOpenAiApiKey,
     loadClaudeApiKey, saveClaudeApiKey,
     loadOllamaApiKey, saveOllamaApiKey,
-    loadAiModels, saveAiModels
+    loadAiModels, saveAiModels,
+    loadThemeConfig, saveThemeConfig
 } = require('../storage');
+const cookie = require('cookie');
 const { getUserAgentConfig, setUserAgentSelection } = require('../../../user-agent-settings');
 const { listProxies, addProxy, addProxies, updateProxy, deleteProxy, deleteProxies, setDefaultProxy, setIncludeDefaultInRotation, setRotationMode } = require('../../../proxy-rotation');
 
@@ -372,6 +374,52 @@ router.post('/ai-models', csrfProtection, dataRateLimiter, requireAuthForSetting
     } catch (e) {
         console.error('[AI_MODELS] Save failed:', e);
         res.status(500).json({ error: 'AI_MODELS_SAVE_FAILED' });
+    }
+});
+
+// Theme Persistence Endpoints
+router.get('/theme', requireAuthForSettings, async (req, res) => {
+    try {
+        let theme = await loadThemeConfig();
+        if (!theme) {
+            // Check for existing theme cookies
+            const cookies = cookie.parse(req.headers.cookie || '');
+            const cookieTheme = cookies['figranium_theme'] || cookies['theme'];
+            const validThemes = ['dark', 'light', 'solarized-light', 'solarized-dark'];
+            if (cookieTheme && validThemes.includes(cookieTheme.trim())) {
+                theme = cookieTheme.trim();
+                await saveThemeConfig(theme);
+            } else {
+                theme = 'dark';
+            }
+        }
+        res.json({ theme });
+    } catch (e) {
+        console.error('[THEME] Load failed:', e);
+        res.status(500).json({ error: 'THEME_LOAD_FAILED' });
+    }
+});
+
+router.post('/theme', csrfProtection, dataRateLimiter, requireAuthForSettings, async (req, res) => {
+    try {
+        const bodyTheme = req.body && typeof req.body.theme === 'string' ? req.body.theme.trim() : '';
+        const validThemes = ['dark', 'light', 'solarized-light', 'solarized-dark'];
+        const selectedTheme = validThemes.includes(bodyTheme) ? bodyTheme : 'dark';
+
+        const savedTheme = await saveThemeConfig(selectedTheme);
+
+        // Set persistent cookie for fast initial page load (1 year TTL)
+        res.setHeader('Set-Cookie', cookie.serialize('figranium_theme', savedTheme, {
+            path: '/',
+            maxAge: 31536000,
+            sameSite: 'lax',
+            httpOnly: false
+        }));
+
+        res.json({ theme: savedTheme });
+    } catch (e) {
+        console.error('[THEME] Save failed:', e);
+        res.status(500).json({ error: 'THEME_SAVE_FAILED' });
     }
 });
 

--- a/src/server/storage.js
+++ b/src/server/storage.js
@@ -12,6 +12,8 @@ const {
     OLLAMA_API_KEY_FILE,
     AI_MODELS_FILE,
     DEFAULT_AI_MODELS,
+    THEME_FILE,
+    DEFAULT_THEME_ID,
     ALLOWED_IPS_FILE,
     STORAGE_STATE_PATH,
     MAX_EXECUTIONS,
@@ -1218,6 +1220,64 @@ async function saveAiModels(models) {
     await fs.promises.writeFile(AI_MODELS_FILE, JSON.stringify(aiModelsCache, null, 2));
 }
 
+// Theme Config Storage
+let themeCache = null;
+
+async function loadThemeConfig() {
+    if (themeCache !== null) return themeCache;
+    const useDB = await ensureDB();
+    if (useDB) {
+        try {
+            const pool = getPool();
+            if (!pool) throw new Error('Database pool not available');
+            const res = await pool.query('SELECT data FROM theme_config WHERE id = 1');
+            if (res.rows.length > 0 && res.rows[0].data && res.rows[0].data.theme) {
+                themeCache = res.rows[0].data.theme;
+            } else {
+                themeCache = null;
+            }
+        } catch (e) {
+            console.error('[STORAGE] Failed to load theme from DB:', e.message);
+            themeCache = null;
+        }
+        return themeCache;
+    }
+    try {
+        const raw = await fs.promises.readFile(THEME_FILE, 'utf8');
+        const parsed = JSON.parse(raw);
+        themeCache = parsed && typeof parsed.theme === 'string' ? parsed.theme : null;
+    } catch {
+        themeCache = null;
+    }
+    return themeCache;
+}
+
+async function saveThemeConfig(themeId) {
+    const validTheme = typeof themeId === 'string' && themeId.trim() ? themeId.trim() : DEFAULT_THEME_ID;
+    themeCache = validTheme;
+    const payload = { theme: validTheme };
+    const useDB = await ensureDB();
+    if (useDB) {
+        const pool = getPool();
+        try {
+            await pool.query('INSERT INTO theme_config (id, data) VALUES (1, $1) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data', [payload]);
+        } catch (e) {
+            console.error('[STORAGE] Failed to save theme to DB:', e.message);
+        }
+        return validTheme;
+    }
+    try {
+        const dir = path.dirname(THEME_FILE);
+        if (!fs.existsSync(dir)) {
+            await fs.promises.mkdir(dir, { recursive: true });
+        }
+        await fs.promises.writeFile(THEME_FILE, JSON.stringify(payload, null, 2));
+    } catch (e) {
+        console.error('[STORAGE] Failed to save theme to file:', e.message);
+    }
+    return validTheme;
+}
+
 module.exports = {
     loadUsers,
     saveUsers,
@@ -1246,5 +1306,7 @@ module.exports = {
     loadAllowedIps,
     getStorageStateFile,
     loadAiModels,
-    saveAiModels
+    saveAiModels,
+    loadThemeConfig,
+    saveThemeConfig
 };

--- a/tests/theme_persistence.test.js
+++ b/tests/theme_persistence.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { loadThemeConfig, saveThemeConfig } = require('../src/server/storage');
+const { THEME_FILE } = require('../src/server/constants');
+
+async function runTests() {
+    console.log('Testing theme persistence storage and endpoints...');
+
+    // Clean up test theme file if exists
+    if (fs.existsSync(THEME_FILE)) {
+        fs.unlinkSync(THEME_FILE);
+    }
+
+    // Test 1: Initial theme config is null or default
+    let initialTheme = await loadThemeConfig();
+    console.log('Initial theme config:', initialTheme);
+    assert.strictEqual(initialTheme, null);
+
+    // Test 2: Save theme config to file / DB
+    const savedTheme = await saveThemeConfig('solarized-dark');
+    assert.strictEqual(savedTheme, 'solarized-dark');
+
+    const loadedTheme = await loadThemeConfig();
+    console.log('Loaded theme after save:', loadedTheme);
+    assert.strictEqual(loadedTheme, 'solarized-dark');
+
+    // Test 3: Save another theme
+    await saveThemeConfig('light');
+    const reloadedTheme = await loadThemeConfig();
+    console.log('Loaded theme after second save:', reloadedTheme);
+    assert.strictEqual(reloadedTheme, 'light');
+
+    console.log('All theme persistence unit tests passed!');
+}
+
+runTests().catch(err => {
+    console.error('Test failed:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
Persist theme preferences to backend storage (file/PostgreSQL) via /api/settings/theme endpoint. Detect existing theme cookies and migrate them to backend data, while setting cookies for instant FOUC-free client application.

---
*PR created automatically by Jules for task [6455888053182292018](https://jules.google.com/task/6455888053182292018) started by @asernasr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent theme selection across sessions and page loads.
  * Theme preferences now synchronize across cookies, local storage, and the server.
  * Added support for retrieving and saving theme preferences.
  * The selected theme is applied before the page renders to reduce visual flicker.
  * Existing saved theme preferences are migrated automatically.

* **Bug Fixes**
  * Added validation and fallback handling for invalid or unavailable theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->