### PR TITLE
Fix v1 qualification false failures and CI setup

### DIFF
--- a/.github/workflows/v1-qualification.yml
+++ b/.github/workflows/v1-qualification.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build frontend
+        run: npm run build
+
       - name: Install Chromium and system dependencies
         run: npx playwright install --with-deps chromium
 

--- a/tests/v1-qualification/suite/02-api.test.js
+++ b/tests/v1-qualification/suite/02-api.test.js
@@ -183,7 +183,9 @@ const tests = [
 
             const proxyRes = await fetch(`${base}/api/settings/proxies`, { headers: h });
             assert.strictEqual(proxyRes.status, 200);
-            assert.ok(Array.isArray(await proxyRes.json()));
+            const proxyData = await proxyRes.json();
+            assert.ok(proxyData && typeof proxyData === 'object');
+            assert.ok(Array.isArray(proxyData.proxies), 'Proxy settings response must expose a proxies array');
 
             const uaRes = await fetch(`${base}/api/settings/user-agent`, { headers: h });
             assert.strictEqual(uaRes.status, 200);

--- a/tests/v1-qualification/suite/03-engine-blocks.test.js
+++ b/tests/v1-qualification/suite/03-engine-blocks.test.js
@@ -143,20 +143,21 @@ const tests = [
     },
     {
         id: 'BLOCK-009', name: 'Control Flow - foreach iterates deterministic DOM collection', subsystem: 'engine-blocks',
-        setup: 'Torture server home page containing multiple links', steps: 'Iterate all anchor elements and increment a page-side counter once per item.',
-        expected: 'For-each emits one item log per anchor and mutates final page state with the same count.', severity: 'CRITICAL', blocksV1: true,
+        setup: 'Torture server home page containing multiple links', steps: 'Iterate all anchor elements, persist the current loop index into a runtime variable, and expose the final loop count/index into page state after the loop.',
+        expected: 'For-each emits one item log per anchor, the loop body runs through the final item, and the final page state reports the same count.', severity: 'CRITICAL', blocksV1: true,
         run: async () => {
             await ensureTortureServer();
             const result = await runFigranite({ url: `${TORTURE_URL}/`, mode: 'agent', actions: [
-                { id: 'fe1', type: 'javascript', value: 'window.qualForeach = 0; document.body.dataset.qualForeach = "0";' },
-                { id: 'fe2', type: 'foreach', selector: 'a' },
-                { id: 'fe3', type: 'javascript', value: 'window.qualForeach += 1; document.body.dataset.qualForeach = String(window.qualForeach);' },
-                { id: 'fe4', type: 'end' }
+                { id: 'fe1', type: 'foreach', selector: 'a' },
+                { id: 'fe2', type: 'set', varName: 'last_foreach_index', value: '{$loop.index}' },
+                { id: 'fe3', type: 'end' },
+                { id: 'fe4', type: 'javascript', value: 'document.body.dataset.qualForeachCount = "{$loop.count}"; document.body.dataset.qualForeachLast = "{$last_foreach_index}";' }
             ] });
             assert.strictEqual(result.outcome, 'success');
             const iterations = result.logs.filter(l => l.includes('For-each item ')).length;
             assert.ok(iterations > 0, 'Foreach must iterate at least one anchor');
-            assert.ok(result.html.includes(`data-qual-foreach="${iterations}"`));
+            assert.ok(result.html.includes(`data-qual-foreach-count="${iterations}"`), 'Final loop.count must match emitted foreach iterations');
+            assert.ok(result.html.includes(`data-qual-foreach-last="${iterations - 1}"`), 'Loop body must execute through the final foreach item');
         }
     },
     {

--- a/tests/v1-qualification/suite/04-engine-runtime.test.js
+++ b/tests/v1-qualification/suite/04-engine-runtime.test.js
@@ -162,8 +162,10 @@ const tests = [
             const headful = await runFigranite(task, { headless: false });
             assert.strictEqual(headless.outcome, 'success');
             assert.strictEqual(headful.outcome, 'success');
-            assert.deepStrictEqual(headful.data, headless.data);
-            assert.strictEqual(headful.data.title, 'Figranium Torture Site');
+            const headlessData = JSON.parse(JSON.stringify(headless.data));
+            const headfulData = JSON.parse(JSON.stringify(headful.data));
+            assert.deepStrictEqual(headfulData, headlessData);
+            assert.strictEqual(headfulData.title, 'Figranium Torture Site');
         }
     },
     {
@@ -171,7 +173,7 @@ const tests = [
         name: 'Engine Runtime - Concurrent Stateless Executions',
         subsystem: 'engine-runtime',
         setup: 'Torture server running',
-        steps: 'Launch four independent stateless executions concurrently with unique input values.',
+        steps: 'Launch four independent stateless executions concurrently with unique input values, reflect each live input value into serialized DOM state, then extract it.',
         expected: 'All four complete successfully and preserve their own input/output state without cross-run contamination.',
         severity: 'CRITICAL',
         blocksV1: true,
@@ -179,8 +181,11 @@ const tests = [
             await ensureTortureServer();
             const runs = Array.from({ length: 4 }, (_, i) => runFigranite({
                 url: `${TORTURE_URL}/form`, mode: 'agent', statelessExecution: true, disableRecording: true,
-                extractionScript: `return { value: document.querySelector('#username-input')?.value };`,
-                actions: [{ id: `c-${i}`, type: 'type', selector: '#username-input', value: `concurrent-${i}` }]
+                extractionScript: 'return { value: document.body.dataset.qualConcurrent || "" };',
+                actions: [
+                    { id: `c-${i}-type`, type: 'type', selector: '#username-input', value: `concurrent-${i}`, typeMode: 'replace' },
+                    { id: `c-${i}-serialize`, type: 'javascript', value: 'document.body.dataset.qualConcurrent = document.querySelector("#username-input")?.value || "";' }
+                ]
             }, { headless: true }));
             const results = await Promise.all(runs);
             results.forEach((result, i) => {

--- a/tests/v1-qualification/suite/08-container-runtime.test.js
+++ b/tests/v1-qualification/suite/08-container-runtime.test.js
@@ -145,7 +145,14 @@ const tests = [
                 await waitForHealth(port);
                 assert.strictEqual(run('docker', ['exec', containerName, 'cat', '/app/data/qualification-marker.txt']), marker, 'Mounted /app/data must survive restart');
             } finally {
-                spawnSync('docker', ['rm', '-f', containerName], { cwd: repoRoot, encoding: 'utf8', timeout: 30_000 });
+                if (dockerAvailable()) {
+                    spawnSync('docker', ['exec', containerName, 'sh', '-c', 'rm -rf /app/data/* /app/data/.[!.]* /app/data/..?* 2>/dev/null || true'], {
+                        cwd: repoRoot,
+                        encoding: 'utf8',
+                        timeout: 30_000
+                    });
+                    spawnSync('docker', ['rm', '-f', containerName], { cwd: repoRoot, encoding: 'utf8', timeout: 30_000 });
+                }
                 fs.rmSync(dataDir, { recursive: true, force: true });
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to #356 based on the first strict GitHub Actions qualification run.

## Fixes

- Correct the proxy settings contract assertion to validate `response.proxies`.
- Make the foreach test validate Figranium loop state instead of relying on the original page-side counter assumption.
- Normalize cross-realm extraction objects before headless/headful equality comparison.
- Make concurrent stateless execution verification serialize each live input value into DOM state before extraction.
- Build the frontend before UI E2E tests so `dist/index.html` exists in CI.
- Clean container-created `/app/data` files from inside the container before host-side temp directory removal, avoiding root-owned bind-mount cleanup failures.

The PR itself will trigger the V1 Qualification workflow so these changes are rerun under the same PostgreSQL + Chromium/Xvfb environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of settings responses and loop behavior.
  - Strengthened runtime consistency checks across execution modes and concurrent runs.
  - Enhanced container cleanup during qualification testing.

- **Chores**
  - Added frontend build verification to the qualification workflow, helping detect build issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->