### PR TITLE
Fix editor run state leaking across tasks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ export default function App() {
         results,
         setResults,
         activeRunId,
+        activeTaskId,
         useNovnc,
         runTaskWithSnapshot,
         stopTask,
@@ -84,6 +85,9 @@ export default function App() {
     const pinnedResultsKey = 'figranium.pinnedResults';
     const getTaskKey = (task?: Task | null) => task?.id ? String(task.id) : 'new';
     const currentTaskKey = getTaskKey(currentTask);
+    const isCurrentTaskExecuting = isExecuting && activeTaskId === currentTaskKey;
+    const isCurrentTaskStopping = isStopping && activeTaskId === currentTaskKey;
+    const currentTaskRunId = isCurrentTaskExecuting ? activeRunId : null;
     const pinnedResults = currentTask ? pinnedResultsByTask[currentTaskKey] || null : null;
 
     useEffect(() => {
@@ -279,8 +283,8 @@ export default function App() {
                                 setEditorView={setEditorView}
                                 triggerExpanded={triggerExpanded}
                                 setTriggerExpanded={setTriggerExpanded}
-                                isExecuting={isExecuting}
-                                isStopping={isStopping}
+                                isExecuting={isCurrentTaskExecuting}
+                                isStopping={isCurrentTaskStopping}
                                 onSave={handleSaveTask}
                                 onRun={() => runTaskWithSnapshot(currentTask, currentTask, setCurrentTask)}
                                 onRunSnapshot={(t) => runTaskWithSnapshot(t || currentTask, currentTask, setCurrentTask)}
@@ -290,7 +294,7 @@ export default function App() {
                                 onNotify={showAlert}
                                 onPinResults={pinResults}
                                 onUnpinResults={unpinResults}
-                                runId={activeRunId}
+                                runId={currentTaskRunId}
                                 onStop={() => stopTask()}
                                 isHeadfulOpen={isHeadfulOpen}
                                 onOpenHeadful={(url, targetActionId, taskSnapshot, variables) => openHeadful(url, targetActionId, taskSnapshot, variables)}
@@ -312,8 +316,8 @@ export default function App() {
                                 setEditorView={setEditorView}
                                 triggerExpanded={triggerExpanded}
                                 setTriggerExpanded={setTriggerExpanded}
-                                isExecuting={isExecuting}
-                                isStopping={isStopping}
+                                isExecuting={isCurrentTaskExecuting}
+                                isStopping={isCurrentTaskStopping}
                                 onSave={handleSaveTask}
                                 onRun={() => runTaskWithSnapshot(currentTask, currentTask, setCurrentTask)}
                                 onRunSnapshot={(t) => runTaskWithSnapshot(t || currentTask, currentTask, setCurrentTask)}
@@ -323,7 +327,7 @@ export default function App() {
                                 onNotify={showAlert}
                                 onPinResults={pinResults}
                                 onUnpinResults={unpinResults}
-                                runId={activeRunId}
+                                runId={currentTaskRunId}
                                 onStop={() => stopTask()}
                                 onTaskLoaded={markTaskAsSaved}
                                 isHeadfulOpen={isHeadfulOpen}

--- a/src/hooks/useExecution.ts
+++ b/src/hooks/useExecution.ts
@@ -10,6 +10,7 @@ export function useExecution(showAlert: (msg: string, tone?: 'success' | 'error'
     const [isHeadfulOpen, setIsHeadfulOpen] = useState(false);
     const [results, setResults] = useState<Results | null>(null);
     const [activeRunId, setActiveRunId] = useState<string | null>(null);
+    const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
     const useNovnc = useHeadfulStatus();
     const executeAbortRef = useRef<AbortController | null>(null);
     const stopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -71,6 +72,7 @@ export function useExecution(showAlert: (msg: string, tone?: 'success' | 'error'
             }
             setIsExecuting(false);
             setIsStopping(false);
+            setActiveTaskId(null);
             showAlert('Execution stopped.', 'success');
         }, 3000);
     };
@@ -78,14 +80,14 @@ export function useExecution(showAlert: (msg: string, tone?: 'success' | 'error'
     const runTaskWithSnapshot = async (taskToRunRaw: Task | null, currentTask: Task | null, setCurrentTask: (t: Task) => void) => {
         if (!taskToRunRaw || !taskToRunRaw.url) return;
         const taskToRun = ensureActionIds(taskToRunRaw);
+        if (isExecuting) return;
         if (currentTask && taskToRun !== currentTask) {
             setCurrentTask(taskToRun);
         }
 
         const runId = `run_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
         setActiveRunId(runId);
-
-        if (isExecuting) return;
+        setActiveTaskId(taskToRun.id ? String(taskToRun.id) : 'new');
 
         setIsExecuting(true);
         setIsStopping(false);
@@ -233,6 +235,7 @@ export function useExecution(showAlert: (msg: string, tone?: 'success' | 'error'
             executeAbortRef.current = null;
             setIsExecuting(false);
             setIsStopping(false);
+            setActiveTaskId(null);
         }
     };
 
@@ -243,6 +246,7 @@ export function useExecution(showAlert: (msg: string, tone?: 'success' | 'error'
         results,
         setResults,
         activeRunId,
+        activeTaskId,
         useNovnc,
         runTaskWithSnapshot,
         stopTask,


### PR DESCRIPTION
## Summary
- track the task ID associated with the active editor execution
- scope editor execution, stopping, and streamed action status to that task
- prevent an attempted second run from changing the active run identity

## Verification
- inspected the final PR patch: it changes only the two execution-state files
- confirmed the branch is based on the current `main`
- automated checks are pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Execution indicators now appear only for the task that is actively running.
  - Prevented unrelated tasks from displaying running or stopping states.
  - Improved task and run tracking when an execution is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->