### PR TITLE
Use secure API key in Docker health qualification

### DIFF
--- a/tests/v1-qualification/suite/08-container-runtime.test.js
+++ b/tests/v1-qualification/suite/08-container-runtime.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -36,6 +37,13 @@ async function ensureImage() {
     imageBuilt = true;
 }
 
+function seedQualificationApiKey(dataDir) {
+    const apiKey = crypto.randomBytes(32).toString('hex');
+    const apiKeyPath = path.join(dataDir, 'api_key.json');
+    fs.writeFileSync(apiKeyPath, JSON.stringify({ apiKey }), { encoding: 'utf8', mode: 0o600 });
+    fs.chmodSync(apiKeyPath, 0o600);
+}
+
 function containerDiagnostics(containerName) {
     const inspect = spawnSync('docker', ['inspect', containerName, '--format', 'status={{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}'], {
         cwd: repoRoot,
@@ -68,10 +76,13 @@ async function waitForContainerHealth(containerName, timeoutMs = 90_000) {
             throw new Error(`Container exited before becoming healthy.\n${containerDiagnostics(containerName)}`);
         }
 
+        // Keep the per-run qualification key out of host command arguments, env vars,
+        // logs, and workflow artifacts. curl reads it from the isolated bind mount
+        // inside the container and sends it using Figranium's normal x-api-key header.
         const health = spawnSync('docker', [
             'exec', containerName,
-            'curl', '-fsS', '--max-time', '2',
-            'http://127.0.0.1:11345/api/health'
+            'sh', '-lc',
+            'curl -fsS --max-time 2 -H "x-api-key: $(node -p \'JSON.parse(require("fs").readFileSync("/app/data/api_key.json", "utf8")).apiKey\')" http://127.0.0.1:11345/api/health'
         ], {
             cwd: repoRoot,
             encoding: 'utf8',
@@ -150,11 +161,11 @@ const tests = [
     },
     {
         id: 'CONTAINER-004',
-        name: 'Docker Runtime - Startup, Health, Restart, and /app/data Volume Persistence',
+        name: 'Docker Runtime - Startup, Authenticated Health, Restart, and /app/data Volume Persistence',
         subsystem: 'container-runtime',
-        setup: 'Built qualification image and working Docker daemon',
-        steps: 'Run the image with an isolated /app/data bind mount and ephemeral published port, verify /api/health from inside the production container, confirm the port is published, create a persistence marker, restart the same container, verify health again and confirm the marker remains.',
-        expected: 'The production container starts, serves a healthy API, publishes port 11345, survives restart, and preserves mounted application data.',
+        setup: 'Built qualification image, working Docker daemon, and an isolated per-run API key stored only in the temporary /app/data bind mount',
+        steps: 'Create an ephemeral API key, run the image with an isolated /app/data bind mount and ephemeral published port, verify /api/health from inside the production container using x-api-key, confirm the port is published, create a persistence marker, restart the same container, verify authenticated health again and confirm the marker remains.',
+        expected: 'The production container starts, serves a healthy authenticated API, publishes port 11345, survives restart, and preserves mounted application data without exposing the qualification key in CI arguments or logs.',
         severity: 'CRITICAL',
         blocksV1: true,
         run: async () => {
@@ -164,6 +175,8 @@ const tests = [
             const containerName = `figranium-v1-qual-${process.pid}-${Date.now()}`;
             const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'figranium-v1-data-'));
             try {
+                seedQualificationApiKey(dataDir);
+
                 run('docker', [
                     'run', '-d', '--name', containerName,
                     '-p', '127.0.0.1::11345',


### PR DESCRIPTION
## Summary

Follow-up to #359: make `CONTAINER-004` exercise `/api/health` with a real per-run API key without exposing that key in GitHub Actions logs, command arguments, environment variables, or artifacts.

## Security approach

- Generate a fresh cryptographically random 32-byte API key for each container test run.
- Store it only in the isolated temporary `/app/data/api_key.json` bind mount with mode `0600`.
- Do **not** pass the key through `docker run -e`, `docker exec -e`, workflow secrets, or host command arguments.
- Read the key from `/app/data/api_key.json` inside the container at probe time and send it through the normal `x-api-key` header.
- Continue deleting the isolated `/app/data` contents and host temp directory during cleanup.
- Container diagnostics remain safe because the key is never printed or persisted in container environment metadata.

The health, restart, port-publish, and persistence assertions remain unchanged otherwise. The V1 Qualification workflow will rerun automatically on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded container-runtime qualification coverage for authenticated health checks.
  - Added validation that per-run API keys are securely isolated and protected with restrictive permissions.
  - Updated test setup to seed authentication credentials before container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->