### PR TITLE
docs: fix local CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Proxy rotation also respects `data/proxies.json` (see below), and `data/allowed_
 
 # CLI & Agent Mode
 
-- Use `npx figranium` (or `npm run cli`) to launch the interactive CLI that shows tasks, status, and logs.
+- Use `npx figranium` (or `node bin/cli.js` from a local checkout) to launch the interactive CLI that shows tasks, status, and logs.
 - Behind the scenes, `bin/cli.js` can invoke `agent.js`, `headful.js`, or `scrape.js` depending on the runtime mode (`--agent`, `--headful`, `--scrape`).
 - Run `node agent.js --help` to see flags like `--task`, `--browser`, or `--version`. These runners share the same settings (API key, proxies, storage) as the web UI.
 - When connecting via the API key, prefer `Authorization: Bearer <key>` so reverse proxies can normalize headers; the CLI also accepts a `--api-key` flag for scripted runs.


### PR DESCRIPTION
Closes #361.

The README currently offers `npm run cli` for local checkouts, but the package has no `cli` script. This replaces that nonexistent command with the repository's existing direct entry point, `node bin/cli.js`; the published-package `npx figranium` option is unchanged.

Validation:

- reproduced the original `npm run cli` missing-script failure after `npm ci`
- `node bin/cli.js --help` succeeds and displays the documented CLI modes
- `node --check bin/cli.js`
- all 9 Markdown files scanned with 0 broken local links
- `git diff --check`

This is a one-line documentation-only correction; it adds no script, dependency, runtime behavior, or package-interface change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the interactive CLI launch instructions to use `node bin/cli.js` when running from a local checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->