### PR TITLE
Set default On Execution Wait to 0 seconds

### DIFF
--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -32,7 +32,7 @@ export const makeDefaultTask = (): Task => ({
     name: "Imported Task",
     url: "",
     mode: "scrape",
-    wait: 3,
+    wait: 0,
     selector: "",
     rotateUserAgents: false,
     rotateProxies: false,
@@ -65,7 +65,7 @@ export const normalizeImportedTask = (raw: any, index: number): Task | null => {
     if (!merged.mode || !['scrape', 'agent', 'headful'].includes(merged.mode)) {
         merged.mode = 'scrape';
     }
-    if (typeof merged.wait !== 'number') merged.wait = 3;
+    if (typeof merged.wait !== 'number') merged.wait = 0;
     if (!merged.stealth) merged.stealth = base.stealth;
     if (!merged.variables || Array.isArray(merged.variables)) merged.variables = {};
     if (!Array.isArray(merged.actions)) merged.actions = [];
@@ -84,7 +84,7 @@ export const buildNewTask = (downloadCabinetId = 'cab_basic'): Task => {
         name: "Task " + Math.floor(Math.random() * 100),
         url: "",
         mode: "agent",
-        wait: 3,
+        wait: 0,
         selector: "",
         rotateUserAgents: false,
         rotateProxies: false,


### PR DESCRIPTION
## Summary
- change the default task-level On Execution Wait from 3 seconds to 0 seconds
- apply the same default when imported tasks omit a wait value
- preserve any explicitly configured wait values

This does not change the Wait action/block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * New and imported tasks now default to a wait value of 0 instead of 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->