### PR TITLE
Fix headful popup focus stealing and add variables shortcut

### DIFF
--- a/headful.js
+++ b/headful.js
@@ -37,6 +37,26 @@ function setActiveHeadfulPage(nextPage) {
     activeSession.page = nextPage;
 }
 
+async function isSiteCreatedPage(nextPage) {
+    if (!nextPage || typeof nextPage.opener !== 'function') return false;
+    try {
+        return !!(await nextPage.opener());
+    } catch {
+        return false;
+    }
+}
+
+async function rejectSiteCreatedPage(nextPage) {
+    if (!(await isSiteCreatedPage(nextPage))) return false;
+
+    const pageToRestore = activeSession?.page;
+    try { await nextPage.close(); } catch { }
+    if (pageToRestore && !pageToRestore.isClosed()) {
+        try { await pageToRestore.bringToFront(); } catch { }
+    }
+    return true;
+}
+
 const teardownActiveSession = async () => {
     if (!activeSession) return;
     try {
@@ -488,13 +508,10 @@ async function runHeadful(data, options = {}) {
             } catch (e) { }
         }
 
+        const trackedPages = new WeakSet();
         const attachPageTracking = (trackedPage) => {
-            if (!trackedPage) return;
-
-            trackedPage.on('popup', (popup) => {
-                setActiveHeadfulPage(popup);
-                attachPageTracking(popup);
-            });
+            if (!trackedPage || trackedPages.has(trackedPage)) return;
+            trackedPages.add(trackedPage);
 
             trackedPage.on('close', () => {
                 if (!activeSession || activeSession.page !== trackedPage) return;
@@ -505,7 +522,8 @@ async function runHeadful(data, options = {}) {
             });
         };
 
-        context.on('page', (newPage) => {
+        context.on('page', async (newPage) => {
+            if (await rejectSiteCreatedPage(newPage)) return;
             setActiveHeadfulPage(newPage);
             attachPageTracking(newPage);
         });
@@ -693,4 +711,3 @@ module.exports = {
     launchApiSession,
     ensureSessionId
 };
-

--- a/src/components/EditorScreen.tsx
+++ b/src/components/EditorScreen.tsx
@@ -357,6 +357,7 @@ const EditorScreen: React.FC<EditorScreenProps> = ({
                 currentTask={currentTask}
                 onUpdateTaskName={(name) => setCurrentTask({ ...currentTask, name })}
                 onAutoSave={handleAutoSave}
+                onOpenVariables={() => handleOpenCabinet('variables')}
                 onOpenHistory={() => handleOpenCabinet('history')}
             />
 

--- a/src/components/editor/EditorTopBar.tsx
+++ b/src/components/editor/EditorTopBar.tsx
@@ -6,6 +6,7 @@ interface EditorTopBarProps {
     currentTask: Task;
     onUpdateTaskName: (name: string) => void;
     onAutoSave: () => void;
+    onOpenVariables: () => void;
     onOpenHistory: () => void;
 }
 
@@ -13,6 +14,7 @@ const EditorTopBar: React.FC<EditorTopBarProps> = ({
     currentTask,
     onUpdateTaskName,
     onAutoSave,
+    onOpenVariables,
     onOpenHistory,
 }) => {
     return (
@@ -29,6 +31,14 @@ const EditorTopBar: React.FC<EditorTopBarProps> = ({
                     />
                 </div>
                 <div className="flex items-center gap-1">
+                    <button
+                        onClick={onOpenVariables}
+                        className="w-8 h-8 rounded-lg flex items-center justify-center text-white/30 hover:text-white hover:bg-white/5 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                        title="Variables"
+                        aria-label="Variables"
+                    >
+                        <MaterialIcon name="function" className="text-base" />
+                    </button>
                     <button
                         onClick={onOpenHistory}
                         className="w-8 h-8 rounded-lg flex items-center justify-center text-white/30 hover:text-white hover:bg-white/5 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50"


### PR DESCRIPTION
## Summary

- prevent site-created popup/tab contexts in Headful mode from becoming the active page or repeatedly stealing focus
- preserve manually opened tabs by only rejecting new pages that Playwright reports as having an opener
- restore focus to the previously active Headful page after rejecting an unsolicited popup
- add a Variables shortcut to the task editor header using the Material `function` icon, immediately to the left of Version History
- wire the shortcut directly to the existing Variables tab in Task Settings

## Notes

The branch diff is intentionally narrow: `headful.js`, `EditorScreen.tsx`, and `EditorTopBar.tsx` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Variables** button to the editor toolbar for quick access to task variables.
  - Opening Variables takes users directly to the Variables tab in task settings.

- **Bug Fixes**
  - Site-created popup pages are now automatically closed, with the previously active page restored.
  - Improved page tracking to prevent duplicate handling and unwanted popup activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->