### PR TITLE
Open On Execution config for new tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <link
         href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
         rel="stylesheet" />
+    <link rel="stylesheet" href="/editor-ui.css" />
     <script>
         (function() {
             try {
@@ -45,6 +46,7 @@
 
 <body class="bg-[#020202] text-gray-100 font-sans h-full overflow-hidden selection:bg-white selection:text-black">
     <div id="root" class="h-full"></div>
+    <script src="/new-task-execution-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/public/editor-ui.css
+++ b/public/editor-ui.css
@@ -1,0 +1,11 @@
+/* Editor-only visual refinements that do not affect dashboard empty states. */
+button[data-action-drop-scope="root"][aria-label="Add action (Ctrl + K)"] > div:first-child {
+    width: auto !important;
+    height: auto !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+}
+
+button[data-action-drop-scope="root"][aria-label="Add action (Ctrl + K)"]:hover > div:first-child {
+    background: transparent !important;
+}

--- a/public/new-task-execution-config.js
+++ b/public/new-task-execution-config.js
@@ -1,0 +1,43 @@
+(() => {
+    let openedForCurrentNewTask = false;
+
+    const maybeOpenExecutionConfig = () => {
+        if (window.location.pathname !== '/tasks/new') {
+            openedForCurrentNewTask = false;
+            return;
+        }
+
+        if (openedForCurrentNewTask) return;
+
+        const button = document.querySelector('button[aria-label="Configure On Execution"]');
+        if (!(button instanceof HTMLButtonElement)) return;
+
+        openedForCurrentNewTask = true;
+        button.click();
+    };
+
+    const notifyRouteChange = () => {
+        queueMicrotask(maybeOpenExecutionConfig);
+    };
+
+    const originalPushState = history.pushState.bind(history);
+    history.pushState = (...args) => {
+        const result = originalPushState(...args);
+        notifyRouteChange();
+        return result;
+    };
+
+    const originalReplaceState = history.replaceState.bind(history);
+    history.replaceState = (...args) => {
+        const result = originalReplaceState(...args);
+        notifyRouteChange();
+        return result;
+    };
+
+    window.addEventListener('popstate', notifyRouteChange);
+
+    const observer = new MutationObserver(maybeOpenExecutionConfig);
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+
+    maybeOpenExecutionConfig();
+})();


### PR DESCRIPTION
## Summary
- automatically open the current **On Execution** popup when `/tasks/new` renders a newly created task
- remove the decorative box around the `+` icon in the root **Add Action** card
- leave dashboard/Create First Task empty-state UI unchanged

## Implementation
- adds a small route/DOM observer that opens the existing `Configure On Execution` button once per new-task route visit
- adds a narrowly scoped CSS override targeting only the root Add Action card icon wrapper
- wires both through `index.html`

## Verification
- branch is based on current `main`
- diff is limited to `index.html`, `public/editor-ui.css`, and `public/new-task-execution-config.js`
- no dashboard files are changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Configure On Execution” panel now opens automatically when creating a new task.
  * This behavior remains consistent when navigating between task pages or using browser history.

* **Style**
  * Updated the editor’s “Add action (Ctrl + K)” button styling for a cleaner, more integrated appearance.
  * The button’s inner element now adapts to its content and uses a transparent background, including on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->