### PR TITLE
Fix UI casing and exclude Headful runs from executions

### DIFF
--- a/src/components/ExecutionDetailScreen.tsx
+++ b/src/components/ExecutionDetailScreen.tsx
@@ -86,6 +86,13 @@ const ExecutionDetailScreen: React.FC<ExecutionDetailScreenProps> = ({ onConfirm
     const results = toResults(execution);
     const outcome = normalizeTaskOutcome(execution.outcome, execution.status);
     const outcomeClass = taskOutcomeBadgeClass(outcome);
+    const metrics = [
+        { label: 'Outcome', value: taskOutcomeLabel(outcome), mono: false },
+        { label: 'Started', value: new Date(execution.timestamp).toLocaleString(), mono: false },
+        { label: 'Source', value: execution.source, mono: true },
+        { label: 'Mode', value: execution.mode, mono: true },
+        { label: 'Runtime', value: `${execution.durationMs}ms`, mono: true },
+    ];
 
     return (
         <main className="app-page custom-scrollbar animate-in fade-in duration-500">
@@ -93,7 +100,11 @@ const ExecutionDetailScreen: React.FC<ExecutionDetailScreenProps> = ({ onConfirm
                 <header className="app-page-header">
                     <div className="space-y-2">
                         <div className="app-page-kicker">Execution detail</div>
-                        <h1 className="app-page-title">{execution.taskName || execution.mode}</h1>
+                        {execution.taskName ? (
+                            <h1 className="app-page-title">{execution.taskName}</h1>
+                        ) : (
+                            <h1 className="app-page-title font-mono">{execution.mode}</h1>
+                        )}
                         <p className="text-xs theme-text-faint font-mono truncate max-w-3xl">{execution.url || execution.path}</p>
                     </div>
                     <button
@@ -108,16 +119,14 @@ const ExecutionDetailScreen: React.FC<ExecutionDetailScreenProps> = ({ onConfirm
                 </header>
 
                 <section className="app-panel grid grid-cols-5 mb-6 max-lg:grid-cols-2 overflow-hidden">
-                    {[
-                        ['Outcome', taskOutcomeLabel(outcome)],
-                        ['Started', new Date(execution.timestamp).toLocaleString()],
-                        ['Source', execution.source],
-                        ['Mode', execution.mode],
-                        ['Runtime', `${execution.durationMs}ms`],
-                    ].map(([label, value], index) => (
+                    {metrics.map(({ label, value, mono }, index) => (
                         <div key={label} className="app-metric !py-4">
                             <div className="app-metric-label">{label}</div>
-                            {index === 0 ? <span className={`app-badge mt-3 ${outcomeClass}`}>{value}</span> : <div className="mt-3 text-xs font-bold theme-text break-words">{value}</div>}
+                            {index === 0 ? (
+                                <span className={`app-badge mt-3 ${outcomeClass}`}>{value}</span>
+                            ) : (
+                                <div className={`mt-3 text-xs font-bold theme-text break-words ${mono ? 'font-mono' : ''}`}>{value}</div>
+                            )}
                         </div>
                     ))}
                 </section>

--- a/src/components/ExecutionsScreen.tsx
+++ b/src/components/ExecutionsScreen.tsx
@@ -8,6 +8,11 @@ import { normalizeTaskOutcome, taskOutcomeBadgeClass, taskOutcomeLabel } from '.
 const EXECUTION_ITEM_SIZE = 94;
 const EXECUTION_LIST_MAX_VISIBLE = 7;
 const EXECUTION_OVERSCAN = 4;
+const FILTER_LABELS = {
+    all: 'All',
+    editor: 'Editor',
+    api: 'API',
+} as const;
 
 interface ExecutionListItemData {
     items: Execution[];
@@ -39,14 +44,18 @@ const renderExecutionRow = ({ index, style, data }: ListChildComponentProps<Exec
                         <MaterialIcon name={execution.source === 'api' ? 'cloud' : 'monitor'} className="text-lg theme-text-faint" />
                     </div>
                     <div className="min-w-0">
-                        <div className="text-xs font-bold theme-text truncate">{execution.taskName || execution.mode}</div>
+                        {execution.taskName ? (
+                            <div className="text-xs font-bold theme-text truncate">{execution.taskName}</div>
+                        ) : (
+                            <div className="text-xs font-bold theme-text font-mono truncate">{execution.mode}</div>
+                        )}
                         <div className="mt-1 text-[10px] theme-text-faint font-mono truncate">{execution.url || new Date(execution.timestamp).toLocaleString()}</div>
                     </div>
                 </div>
                 <div><span className={`app-badge ${taskOutcomeBadgeClass(outcome)}`}>{taskOutcomeLabel(outcome)}</span></div>
-                <div className="text-[11px] theme-text-muted max-lg:hidden"><span className="">{execution.source}</span> · {execution.mode}</div>
+                <div className="text-[11px] theme-text-muted font-mono max-lg:hidden">{execution.source} · {execution.mode}</div>
                 <div className="max-lg:hidden">
-                    <div className="text-[11px] theme-text-muted">{execution.durationMs}ms</div>
+                    <div className="text-[11px] theme-text-muted font-mono">{execution.durationMs}ms</div>
                     <div className="mt-1 text-[10px] theme-text-faint">{new Date(execution.timestamp).toLocaleString()}</div>
                 </div>
                 <button
@@ -134,7 +143,7 @@ const ExecutionsScreen: React.FC<ExecutionsScreenProps> = ({ onConfirm, onNotify
         <main className="app-page custom-scrollbar animate-in fade-in duration-500">
             <div className="app-page-inner">
                 <header className="app-page-header">
-                    <div><h1 className="app-page-title">Executions</h1><p className="app-page-subtitle">Run history and Task outcomes</p></div>
+                    <div><h1 className="app-page-title">Executions</h1><p className="app-page-subtitle">Run history and task outcomes</p></div>
                     <div className="app-toolbar">
                         <button onClick={loadExecutions} disabled={loading} className="app-button-secondary" aria-busy={loading}>
                             <MaterialIcon name="sync" className={`text-base ${loading ? 'animate-spin' : ''}`} /> Refresh
@@ -152,7 +161,7 @@ const ExecutionsScreen: React.FC<ExecutionsScreenProps> = ({ onConfirm, onNotify
                         <div><h2 className="text-sm font-bold theme-text">Run history</h2><p className="mt-1 text-[10px] tracking-[0.14em] theme-text-faint">{filtered.length} executions</p></div>
                         <div role="tablist" className="app-toolbar rounded-xl border theme-border p-1 theme-input">
                             {(['all', 'editor', 'api'] as const).map((mode) => (
-                                <button key={mode} role="tab" aria-selected={filter === mode} onClick={() => setFilter(mode)} className={`min-h-8 px-3 rounded-lg text-[10px] font-bold tracking-widest transition-all ${filter === mode ? 'theme-accent-bg' : 'theme-text-faint hover:theme-text'}`}>{mode}</button>
+                                <button key={mode} role="tab" aria-selected={filter === mode} onClick={() => setFilter(mode)} className={`min-h-8 px-3 rounded-lg text-[10px] font-bold tracking-widest transition-all ${filter === mode ? 'theme-accent-bg' : 'theme-text-faint hover:theme-text'}`}>{FILTER_LABELS[mode]}</button>
                             ))}
                         </div>
                     </div>

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -121,7 +121,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEditTask, onDeleteTask }) =
             </div>
 
             <div className="max-sm:hidden">
-                <span className="app-badge">{task.mode}</span>
+                <span className="app-badge font-mono">{task.mode}</span>
             </div>
 
             <div className="text-[11px] theme-text-muted max-lg:hidden">

--- a/src/server/routes/executions.js
+++ b/src/server/routes/executions.js
@@ -12,6 +12,8 @@ const normalizeExecutionSource = (source) => {
     return !normalized || normalized.toLowerCase() === 'unknown' ? 'api' : normalized;
 };
 
+const isExecutionListEntry = (exec) => exec?.mode !== 'headful';
+
 const getExecutionOutcome = (exec) => normalizeTaskOutcome(
     exec?.outcome || exec?.result?.outcome,
     Number(exec?.status) >= 200 && Number(exec?.status) < 300 ? 'success' : 'error'
@@ -33,12 +35,12 @@ const summarizeExecution = (exec) => ({
 });
 
 router.get('/', requireAuth, async (req, res) => {
-    const executions = await loadExecutions();
+    const executions = (await loadExecutions()).filter(isExecutionListEntry);
     res.json({ executions: executions.map(summarizeExecution) });
 });
 
 router.get('/list', requireApiKey, async (req, res) => {
-    const executions = await loadExecutions();
+    const executions = (await loadExecutions()).filter(isExecutionListEntry);
     res.json({ executions: executions.map(summarizeExecution) });
 });
 
@@ -109,3 +111,4 @@ router.delete('/:id', requireAuth, async (req, res) => {
 module.exports = router;
 module.exports.getExecutionOutcome = getExecutionOutcome;
 module.exports.summarizeExecution = summarizeExecution;
+module.exports.isExecutionListEntry = isExecutionListEntry;


### PR DESCRIPTION
## Summary
- render execution filter controls in normal user-facing case (`All`, `Editor`, `API`)
- keep human-readable task names and labels proportional while rendering technical lowercase identifiers such as modes, sources, runtimes, URLs, and fallback mode titles in monospace
- align task cards and execution details with the same typography rule
- exclude `headful` runs from both execution list endpoints so they no longer appear as failed runs or affect execution metrics

## Notes
- existing persisted Headful records are also excluded from list responses
- direct execution detail behavior is unchanged for any pre-existing deep links

## Validation
- reviewed the branch diff against `main`; changes are limited to the execution UI, task mode badge, and execution list API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Execution details now present key metrics more consistently, with clearer task, source, and mode styling.
  * Execution lists display user-friendly filter labels and show task names when available, with mode as a fallback.
  * Task mode badges and relevant execution values now use monospace styling for improved readability.
  * Updated execution page subtitle text for clearer presentation.

* **Behavior Changes**
  * Headful-mode executions are no longer shown in execution listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->