### PR TITLE
Add canonical shared UI boundary for Figranium Embed

### DIFF
--- a/src/embed/README.md
+++ b/src/embed/README.md
@@ -1,0 +1,19 @@
+# Figranium Embed UI contract
+
+This directory defines the public boundary that Figranium Embed should consume.
+
+## Goal
+
+Figranium Embed must never maintain a visual copy of the task editor. The canonical task UI remains in Figranium under `src/components/editor` and related shared components/utilities. Embed should consume those components directly (or a package built from them), so editor redesigns flow into future Embed releases automatically.
+
+## Scope
+
+Embed is UI-only. It accepts Figranium task JSON and renders the task/editor surface without requiring a Figranium server.
+
+It does not provide browser execution, Open Browser, noVNC, selector picking, scheduling, authentication, or server persistence. Applications that want execution should wire their own controls to the Figranium SDK/API.
+
+## Compatibility rule
+
+The source of truth is the Figranium repository. Do not fork/copy JSX or CSS into `figranium-embed`.
+
+When editor UI changes, the Embed package should be rebuilt against the corresponding Figranium UI export. Package versions should track the Figranium release they were built from where practical.

--- a/src/embed/index.ts
+++ b/src/embed/index.ts
@@ -1,0 +1,22 @@
+// Canonical UI exports for Figranium Embed.
+//
+// Keep this file intentionally narrow. `figranium-embed` should depend on these
+// exports rather than copying editor implementation or styles. That guarantees
+// future Embed releases are built from the same source UI as Figranium itself.
+
+export { default as CanvasView } from '../components/editor/CanvasView';
+export { default as ActionItem } from '../components/editor/ActionItem';
+export { default as EditorTopBar } from '../components/editor/EditorTopBar';
+export { default as StickyNote } from '../components/editor/StickyNote';
+export { default as MaterialIcon } from '../components/MaterialIcon';
+export { default as RichInput } from '../components/RichInput';
+export { default as CodeEditor } from '../components/CodeEditor';
+export { default as CustomSelect } from '../components/common/CustomSelect';
+
+export * from '../types';
+export * from '../components/editor/actionCatalog';
+export * from '../components/editor/extractionOptions';
+export * from '../utils/actionBlocks';
+export * from '../utils/extractionScriptGen';
+export * from '../utils/extractionFieldIds';
+export * from '../utils/theme';

--- a/src/embed/styles.css
+++ b/src/embed/styles.css
@@ -1,0 +1,9 @@
+/*
+ * Canonical Figranium Embed style entrypoint.
+ *
+ * Consumers should import this file (or a built package derived from it)
+ * instead of copying Figranium's CSS. This keeps Embed visually aligned with
+ * the Figranium release it targets.
+ */
+
+@import '../index.css';


### PR DESCRIPTION
## Summary

Creates the canonical UI export boundary that `figranium-embed` should consume so the embed never becomes a visual fork of Figranium.

- exports the existing editor components from `src/embed/index.ts`
- exposes the canonical Figranium stylesheet via `src/embed/styles.css`
- documents the no-copy/no-drift contract
- explicitly keeps Embed UI-only: no Open Browser, no noVNC, no selector picker, no execution runtime

The intent is that future `figranium-embed` releases are built from these exports, so changes to Figranium's editor become changes to Embed from the same source rather than by manual reimplementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an embeddable, UI-only task editor surface that renders task data without requiring a Figranium server.
  - Added reusable editor components, controls, utilities, and shared styling for Embed integrations.
  - Added a canonical package entry point for accessing Embed UI capabilities.

- **Documentation**
  - Documented Embed’s supported scope, integration requirements, compatibility expectations, and excluded features such as browser execution, authentication, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->