### PR TITLE
Add canonical read-only canvas for iframe embeds

### DIFF
--- a/src/embed/ReadOnlyCanvas.tsx
+++ b/src/embed/ReadOnlyCanvas.tsx
@@ -1,0 +1,58 @@
+import React, { useRef } from 'react';
+import CanvasView from '../components/editor/CanvasView';
+import type { Task } from '../types';
+
+export interface ReadOnlyCanvasProps {
+  task: Task;
+  className?: string;
+}
+
+const noop = () => {};
+
+/** Canonical inert Figranium task canvas for embeds and previews. */
+const ReadOnlyCanvas: React.FC<ReadOnlyCanvasProps> = ({ task, className = '' }) => {
+  const canvasViewportRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className={`relative h-full w-full pointer-events-none select-none ${className}`.trim()} aria-hidden="true">
+      <CanvasView
+        currentTask={task}
+        setCurrentTask={noop as (task: Task) => void}
+        canvasOffset={{ x: 0, y: 0 }}
+        canvasScale={1}
+        canvasViewportRef={canvasViewportRef}
+        triggerExpanded={false}
+        setTriggerExpanded={noop}
+        onOpenCabinet={noop}
+        handleAutoSave={noop}
+        dragState={null}
+        dragOverIndex={null}
+        selectedActionIds={new Set()}
+        setSelectedActionIds={noop as (ids: Set<string>) => void}
+        actionStatusById={{}}
+        availableTasks={[]}
+        selectorOptionsById={{}}
+        updateAction={noop as any}
+        openActionPalette={noop as any}
+        openContextMenu={noop as any}
+        handleActionPointerDown={noop as any}
+        onOpenHeadful={noop as any}
+        isHeadfulOpen={false}
+        onPointerDown={noop as any}
+        onPointerMove={noop as any}
+        onPointerUp={noop}
+        onPointerCancel={noop}
+        selectionBox={null}
+        onAddStickyNote={noop as any}
+        onUpdateStickyNote={noop as any}
+        onDeleteStickyNote={noop as any}
+        onDuplicateStickyNote={noop as any}
+        selectedNoteIds={new Set()}
+        autoOpenActionId={null}
+        onClearAutoOpenActionId={noop}
+      />
+    </div>
+  );
+};
+
+export default ReadOnlyCanvas;

--- a/src/embed/index.ts
+++ b/src/embed/index.ts
@@ -4,6 +4,8 @@
 // exports rather than copying editor implementation or styles. That guarantees
 // future Embed releases are built from the same source UI as Figranium itself.
 
+export { default as ReadOnlyCanvas } from './ReadOnlyCanvas';
+export type { ReadOnlyCanvasProps } from './ReadOnlyCanvas';
 export { default as CanvasView } from '../components/editor/CanvasView';
 export { default as ActionItem } from '../components/editor/ActionItem';
 export { default as EditorTopBar } from '../components/editor/EditorTopBar';


### PR DESCRIPTION
Adds a purpose-built `ReadOnlyCanvas` export for Figranium Embed. The wrapper renders the real `CanvasView` while sealing all mutation, browser, picker, persistence, and interaction callbacks to inert no-ops. This lets iframe consumers depend on a stable read-only API instead of the editor's internal prop surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only canvas for embeds and previews.
  - Canvas content can be viewed without editing, selecting, dragging, or triggering actions.
  - Added public access to the read-only canvas component and its configuration type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->