### PR TITLE
Publish canonical CSS for Figranium Embed

### DIFF
--- a/.github/workflows/publish-embed-assets.yml
+++ b/.github/workflows/publish-embed-assets.yml
@@ -1,0 +1,48 @@
+name: Publish Embed Assets
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - src/**
+      - tailwind.config.js
+      - postcss.config.js
+      - package.json
+      - package-lock.json
+      - .github/workflows/publish-embed-assets.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npm run build
+      - name: Publish canonical compiled embed CSS
+        run: |
+          CSS_FILE=$(find dist/assets -maxdepth 1 -type f -name '*.css' | head -n 1)
+          if [ -z "$CSS_FILE" ]; then
+            echo 'No compiled CSS asset found.' >&2
+            exit 1
+          fi
+
+          mkdir -p /tmp/figranium-embed-assets
+          cp "$CSS_FILE" /tmp/figranium-embed-assets/embed.css
+          printf '{"commit":"%s","generatedAt":"%s"}\n' "$GITHUB_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /tmp/figranium-embed-assets/metadata.json
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout --orphan embed-assets
+          git rm -rf .
+          cp /tmp/figranium-embed-assets/embed.css ./embed.css
+          cp /tmp/figranium-embed-assets/metadata.json ./metadata.json
+          git add embed.css metadata.json
+          git commit -m "chore: publish embed assets for $GITHUB_SHA"
+          git push --force origin embed-assets


### PR DESCRIPTION
Adds a GitHub Actions workflow that rebuilds Figranium on UI/style changes and force-publishes the compiled canonical stylesheet to the `embed-assets` branch as `embed.css`, with commit metadata.

This gives Figranium Embed a stable live CSS source without introducing a hosted iframe endpoint. Embed can prefer the live compiled stylesheet and fall back to its bundled CSS when offline or unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated publishing of embed assets after relevant changes to the main branch.
  * Added support for manually triggering the embed asset build and publishing process.
  * Publishes compiled styling and build metadata to a dedicated asset branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->