### PR TITLE
Hide edit controls in read-only task canvas

### DIFF
--- a/src/embed/ReadOnlyCanvas.tsx
+++ b/src/embed/ReadOnlyCanvas.tsx
@@ -29,7 +29,10 @@ const ReadOnlyCanvas: React.FC<ReadOnlyCanvasProps> = ({ task, className = '' })
   }, []);
 
   return (
-    <div className={`relative flex h-full w-full pointer-events-none select-none ${className}`.trim()} aria-hidden="true">
+    <div
+      className={`relative flex h-full w-full pointer-events-none select-none [&_button]:hidden ${className}`.trim()}
+      aria-hidden="true"
+    >
       <CanvasView
         currentTask={task}
         setCurrentTask={noop as (task: Task) => void}


### PR DESCRIPTION
Makes the canonical `ReadOnlyCanvas` visually read-only as well as behaviorally inert by hiding descendant button controls. Existing task content remains visible, while add/settings/tune controls no longer appear in embeds or previews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Read-only canvases now consistently prevent interaction and text selection.
  - Buttons within read-only canvases are now hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->