### PR TITLE
Target edit controls in read-only canvas

### DIFF
--- a/src/embed/ReadOnlyCanvas.tsx
+++ b/src/embed/ReadOnlyCanvas.tsx
@@ -30,7 +30,7 @@ const ReadOnlyCanvas: React.FC<ReadOnlyCanvasProps> = ({ task, className = '' })
 
   return (
     <div
-      className={`relative flex h-full w-full pointer-events-none select-none [&_button]:hidden ${className}`.trim()}
+      className={`figranium-readonly-canvas relative flex h-full w-full pointer-events-none select-none ${className}`.trim()}
       aria-hidden="true"
     >
       <CanvasView

--- a/src/embed/styles.css
+++ b/src/embed/styles.css
@@ -7,3 +7,10 @@
  */
 
 @import '../index.css';
+
+/* Presentation-only controls are omitted without hiding task labels/content. */
+.figranium-readonly-canvas button[data-action-drop-scope],
+.figranium-readonly-canvas button[aria-label="Configure block"],
+.figranium-readonly-canvas button[aria-label="Open Task Settings"] {
+  display: none !important;
+}


### PR DESCRIPTION
Replaces the overly broad descendant-button hiding with targeted read-only presentation rules. Task labels and trigger/action titles remain visible, while add-action, block-config, and task-settings controls are omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved read-only canvas display by hiding presentation-only controls while keeping task labels and content visible.
  - Preserved relevant interactive buttons that were previously hidden indiscriminately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->