### PR TITLE
Hide insertion controls in read-only canvas

### DIFF
--- a/src/embed/styles.css
+++ b/src/embed/styles.css
@@ -10,6 +10,7 @@
 
 /* Presentation-only controls are omitted without hiding task labels/content. */
 .figranium-readonly-canvas button[data-action-drop-scope],
+.figranium-readonly-canvas button[aria-label^="Add action"],
 .figranium-readonly-canvas button[aria-label="Configure block"],
 .figranium-readonly-canvas button[aria-label="Open Task Settings"] {
   display: none !important;


### PR DESCRIPTION
Covers every Add action insertion button in the canonical read-only presentation, including between-block controls that do not carry `data-action-drop-scope`. Task labels and summaries remain visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the “Add action” control in read-only canvases to prevent presentation-only actions from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->