### PR TITLE
Preserve dot grid in read-only Embed canvas

### DIFF
--- a/src/embed/ReadOnlyCanvas.tsx
+++ b/src/embed/ReadOnlyCanvas.tsx
@@ -32,6 +32,7 @@ const ReadOnlyCanvas: React.FC<ReadOnlyCanvasProps> = ({ task, className = '' })
     <div
       className={`figranium-readonly-canvas relative flex h-full w-full pointer-events-none select-none ${className}`.trim()}
       aria-hidden="true"
+      style={{ '--app-dot': 'rgba(255, 255, 255, 0.12)' } as React.CSSProperties}
     >
       <CanvasView
         currentTask={task}


### PR DESCRIPTION
Keeps Figranium's canonical 22px dot grid visible in read-only Embed/previews by ensuring the canonical dark-theme `--app-dot` token is present even when the full app theme manager is not mounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated embedded canvas styling to use a white dot color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->