### PR TITLE
Keep sticky notes above blocks in Embed

### DIFF
--- a/src/embed/styles.css
+++ b/src/embed/styles.css
@@ -8,6 +8,11 @@
 
 @import '../index.css';
 
+/* Read-only sticky notes should remain visible even when positioned over blocks. */
+.figranium-readonly-canvas [data-sticky-note-id] {
+  z-index: 20 !important;
+}
+
 /* Presentation-only controls are omitted without hiding task labels/content. */
 .figranium-readonly-canvas button[data-action-drop-scope],
 .figranium-readonly-canvas button[aria-label^="Add action"],


### PR DESCRIPTION
In the editor, sticky notes intentionally use z-index 5 beneath the block stack. For the canonical read-only Embed presentation, raise sticky notes to z-index 20 so getting-started notes remain readable when their saved coordinates overlap blocks. Editor behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Sticky notes now remain visible above overlapping blocks in read-only canvases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->