### PR TITLE
Restore canonical sticky-note layering in Embed

### DIFF
--- a/src/embed/styles.css
+++ b/src/embed/styles.css
@@ -8,11 +8,6 @@
 
 @import '../index.css';
 
-/* Read-only sticky notes should remain visible even when positioned over blocks. */
-.figranium-readonly-canvas [data-sticky-note-id] {
-  z-index: 20 !important;
-}
-
 /* Presentation-only controls are omitted without hiding task labels/content. */
 .figranium-readonly-canvas button[data-action-drop-scope],
 .figranium-readonly-canvas button[aria-label^="Add action"],


### PR DESCRIPTION
Reverts the read-only-only z-index override so sticky notes remain behind task blocks when they overlap, matching the canonical editor behavior. The Templates Hub managed getting-started note keeps its corrected left-side placement, so normal embeds avoid overlap without changing stacking semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated read-only canvas layering behavior by removing the forced topmost display of sticky notes above blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->