### PR TITLE
Fix sticky note editing in Embed

### DIFF
--- a/src/embed/ReadOnlyCanvas.tsx
+++ b/src/embed/ReadOnlyCanvas.tsx
@@ -42,6 +42,29 @@ const ReadOnlyCanvas: React.FC<ReadOnlyCanvasProps> = ({ task, className = '' })
     return () => observer.disconnect();
   }, [task]);
 
+  useLayoutEffect(() => {
+    const viewport = canvasViewportRef.current;
+    if (!viewport) return;
+
+    const lockStickyNotes = () => {
+      viewport.querySelectorAll<HTMLElement>('[data-sticky-note-id]').forEach(note => {
+        note.style.pointerEvents = 'none';
+        note.setAttribute('inert', '');
+
+        note.querySelectorAll<HTMLTextAreaElement>('textarea').forEach(textarea => {
+          textarea.readOnly = true;
+          textarea.tabIndex = -1;
+          if (document.activeElement === textarea) textarea.blur();
+        });
+      });
+    };
+
+    lockStickyNotes();
+    const observer = new MutationObserver(lockStickyNotes);
+    observer.observe(viewport, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [task]);
+
   useEffect(() => {
     const viewport = canvasViewportRef.current;
     if (!viewport) return;


### PR DESCRIPTION
Locks sticky notes inside the canonical read-only canvas so Embed cannot enter local edit mode, drag/resize notes, open their context menu, or focus editable textareas. Pointer events pass through to the canvas so panning still works over sticky notes. This is enforced client-side; Embed has no persistence path, so no server-side change is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sticky notes in embedded canvases are now consistently read-only.
  - Users can no longer edit, focus, or interact with sticky notes in the read-only view, including notes that appear dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->