### PR TITLE
Fix read-only context menu and task mode casing

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Task } from '../types';
 import MaterialIcon from './MaterialIcon';
 import { copyToClipboard } from '../utils/clipboard';
+import { formatLabel } from '../utils/taskUtils';
 
 interface TaskCardProps {
     task: Task;
@@ -121,7 +122,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEditTask, onDeleteTask }) =
             </div>
 
             <div className="max-sm:hidden">
-                <span className="app-badge font-mono">{task.mode}</span>
+                <span className="app-badge font-mono">{formatLabel(task.mode)}</span>
             </div>
 
             <div className="text-[11px] theme-text-muted max-lg:hidden">

--- a/src/embed/ReadOnlyCanvas.tsx
+++ b/src/embed/ReadOnlyCanvas.tsx
@@ -114,6 +114,10 @@ const ReadOnlyCanvas: React.FC<ReadOnlyCanvasProps> = ({ task, className = '' })
       className={`figranium-readonly-canvas relative flex h-full w-full select-none cursor-grab active:cursor-grabbing ${className}`.trim()}
       aria-label="Read-only Figranium task canvas. Drag or scroll to pan."
       style={{ '--app-dot': 'rgba(255, 255, 255, 0.12)', touchAction: 'none' } as React.CSSProperties}
+      onContextMenuCapture={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
       onPointerDown={startPanning}
       onPointerMove={movePanning}
       onPointerUp={stopPanning}


### PR DESCRIPTION
Prevents the editor canvas context menu from opening inside the canonical ReadOnlyCanvas, so Embed no longer shows the inert “Add sticky note” action on right-click. Also normalizes task mode badges to title case (`Agent`, `Scrape`) instead of exposing raw mode casing.