### PR TITLE
Fix false anti-bot outcome after CAPTCHA solve

### DIFF
--- a/src/agent/outcomes.js
+++ b/src/agent/outcomes.js
@@ -25,7 +25,7 @@ const findAntiBotReason = ({ status, url, title, html, captchaResolved = false }
     }
 
     const currentUrl = String(url || '').toLowerCase();
-    if (/\/cdn-cgi\/(challenge|challenge-platform)\b/.test(currentUrl)) {
+    if (!captchaResolved && /\/cdn-cgi\/(challenge|challenge-platform)\b/.test(currentUrl)) {
         return 'Cloudflare challenge URL detected';
     }
 
@@ -36,18 +36,18 @@ const findAntiBotReason = ({ status, url, title, html, captchaResolved = false }
         || /<(?:input|textarea)\b[^>]+name=["'](?:g-recaptcha-response|h-captcha-response|cf-turnstile-response)["']/i.test(activeMarkup);
 
     if (hasChallengeWidget && !captchaResolved) return 'unresolved CAPTCHA challenge detected';
-    if (normalized.includes('just a moment')
+    if (!captchaResolved && normalized.includes('just a moment')
         && /(checking your browser|performing security verification|enable javascript and cookies)/.test(normalized)) {
         return 'browser verification challenge page detected';
     }
-    if (normalized.includes('attention required') && normalized.includes('cloudflare')) {
+    if (!captchaResolved && normalized.includes('attention required') && normalized.includes('cloudflare')) {
         return 'Cloudflare access challenge detected';
     }
     if (normalized.includes('access denied')
         && /(request blocked|security service|incident id|reference #)/.test(normalized)) {
         return 'access-denied block page detected';
     }
-    if (normalized.includes('verify you are human') && /(captcha|security check|robot)/.test(normalized)) {
+    if (!captchaResolved && normalized.includes('verify you are human') && /(captcha|security check|robot)/.test(normalized)) {
         return 'human-verification challenge detected';
     }
 

--- a/tests/task_outcomes.test.js
+++ b/tests/task_outcomes.test.js
@@ -48,6 +48,16 @@ async function run() {
         html: '<div class="h-captcha" data-sitekey="key"></div>',
         captchaResolved: true
     }), null);
+    assert.strictEqual(findAntiBotReason({
+        url: 'https://example.com/cdn-cgi/challenge-platform/test',
+        captchaResolved: true
+    }), null);
+    assert.strictEqual(findAntiBotReason({
+        title: 'Just a moment...',
+        html: '<main>Checking your browser before accessing the site</main>',
+        captchaResolved: true
+    }), null);
+    assert.match(findAntiBotReason({ status: 403, captchaResolved: true }), /HTTP 403/);
 
     const unresolvedPage = {
         url: () => 'https://example.com',
@@ -57,6 +67,14 @@ async function run() {
     };
     assert.strictEqual((await inspectPageForAntiBot(unresolvedPage)).detected, true);
     assert.strictEqual((await inspectPageForAntiBot({ ...unresolvedPage, evaluate: async () => true })).detected, false);
+
+    const solvedChallengePage = {
+        url: () => 'https://example.com/cdn-cgi/challenge-platform/test',
+        title: async () => 'Just a moment...',
+        content: async () => '<main>Checking your browser before accessing the site</main><textarea name="g-recaptcha-response">token</textarea>',
+        evaluate: async () => true
+    };
+    assert.strictEqual((await inspectPageForAntiBot(solvedChallengePage)).detected, false);
 
     let stopPending = true;
     let clearedRunId = null;


### PR DESCRIPTION
## Summary
- prevent challenge URL/page heuristics from classifying a task as `anti_bot` after a CAPTCHA response has been successfully populated
- keep hard block signals such as HTTP 403/429 and explicit access-denied pages intact
- add regression coverage for solved Cloudflare/challenge-page cases

## Why
The anti-bot detector already tracked `captchaResolved`, but only used it to suppress the challenge-widget heuristic. A successfully solved CAPTCHA could therefore still be marked `anti_bot` because the final URL or page text retained challenge markers.

## Testing
Adds focused coverage in `tests/task_outcomes.test.js`, including a solved challenge URL/page and a guard ensuring HTTP 403 remains classified as anti-bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved CAPTCHA challenges are no longer incorrectly flagged as anti-bot blocks based on Cloudflare challenge or browser-verification indicators.
  - Access-denied pages, including HTTP 403 responses, continue to be detected correctly.
  - Pages with successfully completed challenges are now recognized as accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->