### PR TITLE
Fix authenticated tabs reopening in headful mode

### DIFF
--- a/browser-storage-state.js
+++ b/browser-storage-state.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+const SHARED_BROWSER_STATE_PATH = path.join(__dirname, 'data', 'headful-storage-state.json');
+let pendingWrite = Promise.resolve();
+
+function normalizeBrowserState(state) {
+    const now = Date.now() / 1000;
+    return {
+        cookies: (Array.isArray(state?.cookies) ? state.cookies : [])
+            .filter(cookie => !cookie.expires || cookie.expires === -1 || cookie.expires > now),
+        origins: Array.isArray(state?.origins) ? state.origins : []
+    };
+}
+
+async function loadSharedBrowserState() {
+    try {
+        return normalizeBrowserState(JSON.parse(await fs.promises.readFile(SHARED_BROWSER_STATE_PATH, 'utf8')));
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            console.warn('[BROWSER STATE] Failed to load shared browser state:', error.message);
+        }
+        return null;
+    }
+}
+
+async function saveSharedBrowserState(context, options = {}) {
+    if (!context) return;
+
+    let state;
+    try {
+        state = normalizeBrowserState(await context.storageState({ indexedDB: true }));
+    } catch (error) {
+        console.error('[BROWSER STATE] Failed to capture shared browser state:', error.message);
+        return;
+    }
+
+    const write = async () => {
+        if (options.preserveOrigins) {
+            const existingState = await loadSharedBrowserState();
+            state.origins = existingState?.origins || [];
+        }
+        await fs.promises.mkdir(path.dirname(SHARED_BROWSER_STATE_PATH), { recursive: true });
+        const temporaryPath = `${SHARED_BROWSER_STATE_PATH}.${process.pid}.${Date.now()}.tmp`;
+        try {
+            await fs.promises.writeFile(temporaryPath, JSON.stringify(state, null, 2));
+            await fs.promises.rename(temporaryPath, SHARED_BROWSER_STATE_PATH);
+        } finally {
+            await fs.promises.unlink(temporaryPath).catch(() => {});
+        }
+    };
+
+    pendingWrite = pendingWrite.then(write, write);
+    try {
+        await pendingWrite;
+    } catch (error) {
+        console.error('[BROWSER STATE] Failed to save shared browser state:', error.message);
+    }
+}
+
+module.exports = {
+    SHARED_BROWSER_STATE_PATH,
+    loadSharedBrowserState,
+    saveSharedBrowserState
+};

--- a/headful.js
+++ b/headful.js
@@ -1,32 +1,13 @@
 const { chromium } = require('./stealth-chromium');
-const fs = require('fs');
-const path = require('path');
 const { getProxySelection } = require('./proxy-rotation');
 const { selectUserAgent } = require('./user-agent-settings');
 const { validateUrl, setupNavigationProtection } = require('./url-utils');
 const { parseBooleanFlag } = require('./common-utils');
 const { installPageTranslation } = require('./src/agent/translate');
 const { Mutex } = require('./src/server/utils');
-
-const HEADFUL_PROFILE_DIR = path.join(__dirname, 'data', 'browser-profile-headful');
-const HEADFUL_STATE_PATH = path.join(__dirname, 'data', 'headful-storage-state.json');
+const { loadSharedBrowserState, saveSharedBrowserState } = require('./browser-storage-state');
 
 const headfulMutex = new Mutex();
-
-async function saveHeadfulStorageState(context) {
-    if (!context) return;
-    try {
-        const state = await context.storageState();
-        const now = Date.now() / 1000;
-        const cookies = (state.cookies || []).filter(c => !c.expires || c.expires === -1 || c.expires > now);
-        if (cookies.length === 0) return;
-        await fs.promises.mkdir(path.join(__dirname, 'data'), { recursive: true });
-        await fs.promises.writeFile(HEADFUL_STATE_PATH, JSON.stringify({ cookies }, null, 2));
-        console.log(`[HEADFUL] Saved ${cookies.length} cookies to headful-storage-state.json`);
-    } catch (e) {
-        console.error('[HEADFUL] Failed to save storage state:', e.message);
-    }
-}
 
 const EventEmitter = require('events');
 const headfulEventEmitter = new EventEmitter();
@@ -64,7 +45,7 @@ const teardownActiveSession = async () => {
         if (activeSession.interval) clearInterval(activeSession.interval);
     } catch { }
     if (activeSession.context && !activeSession.statelessExecution) {
-        await saveHeadfulStorageState(activeSession.context);
+        await saveSharedBrowserState(activeSession.context);
     }
     try {
         if (activeSession.browser) {
@@ -166,18 +147,17 @@ async function runHeadful(data, options = {}) {
 
             const isHeadless = parseBooleanFlag(data.headless) || parseBooleanFlag(process.env.HEADLESS);
 
-            if (statelessExecution) {
-                browser = await chromium.launch({ headless: isHeadless, args, ...(cleanProxy ? { proxy: cleanProxy } : {}) });
-                context = await browser.newContext(contextOptions);
-            } else {
-                await fs.promises.mkdir(HEADFUL_PROFILE_DIR, { recursive: true });
-                // Remove stale lock files left by a previous container/process to prevent launch failure
-                for (const lockFile of ['SingletonLock', 'SingletonCookie', 'SingletonSocket']) {
-                    try { await fs.promises.unlink(path.join(HEADFUL_PROFILE_DIR, lockFile)); } catch { }
-                }
-                context = await chromium.launchPersistentContext(HEADFUL_PROFILE_DIR, { headless: isHeadless, args, ...contextOptions });
-                browser = context.browser();
+            if (!statelessExecution) {
+                const storageState = await loadSharedBrowserState();
+                if (storageState) contextOptions.storageState = storageState;
             }
+
+            // A persistent Chromium profile also restores tab/session and service-worker
+            // state. Authenticated sites can consequently reopen background tabs, which
+            // then fight the popup guard and visibly flash open and closed. A fresh
+            // context preserves the explicit web storage above without reviving tabs.
+            browser = await chromium.launch({ headless: isHeadless, args, ...(cleanProxy ? { proxy: cleanProxy } : {}) });
+            context = await browser.newContext(contextOptions);
         }
 
         const inspectInitFn = () => {
@@ -537,7 +517,7 @@ async function runHeadful(data, options = {}) {
 
         const syncInterval = statelessExecution ? null : setInterval(() => {
             if (activeSession && activeSession.context) {
-                saveHeadfulStorageState(activeSession.context).catch(() => {});
+                saveSharedBrowserState(activeSession.context).catch(() => {});
             }
         }, 30000);
         activeSession = { browser, context, page, status: 'running', startedAt: activeSession.startedAt, inspectModeEnabled: activeSession.inspectModeEnabled, statelessExecution, interval: syncInterval };
@@ -559,7 +539,7 @@ async function runHeadful(data, options = {}) {
         }
         if (syncInterval) clearInterval(syncInterval);
         if (!statelessExecution && context) {
-            await saveHeadfulStorageState(context).catch(() => {});
+            await saveSharedBrowserState(context).catch(() => {});
         }
         activeSession = null;
         return responseData;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "agent.js",
     "headful.js",
     "scrape.js",
+    "browser-storage-state.js",
     "common-utils.js",
     "html-utils.js",
     "url-utils.js",

--- a/scrape.js
+++ b/scrape.js
@@ -10,8 +10,8 @@ const { toCsvString } = require('./common-utils');
 const { resolveTaskOutcome, findAntiBotReason } = require('./src/agent/outcomes');
 const { consumeStopRequest, clearStopRequest, registerActiveRun, unregisterActiveRun } = require('./src/agent/execution-control');
 const { sendExecutionUpdate } = require('./src/server/state');
+const { loadSharedBrowserState } = require('./browser-storage-state');
 
-const HEADFUL_STATE_PATH = path.join(__dirname, 'data', 'headful-storage-state.json');
 const USELESS_SELECTOR = 'script, style, svg, link, noscript';
 
 class ScrapeInputError extends Error {
@@ -33,20 +33,19 @@ function buildProxyUrl(proxy) {
 
 async function buildCookieHeader(targetUrl) {
     try {
-        const raw = await fs.promises.readFile(HEADFUL_STATE_PATH, 'utf8');
-        const state = JSON.parse(raw);
+        const state = await loadSharedBrowserState();
         const now = Date.now() / 1000;
         const hostname = new URL(targetUrl).hostname;
-        const cookies = (state.cookies || []).filter(c => {
+        const cookies = (state?.cookies || []).filter(c => {
             if (c.expires && c.expires !== -1 && c.expires <= now) return false;
             const domain = (c.domain || '').replace(/^\./, '');
             return hostname === domain || hostname.endsWith(`.${domain}`);
         });
         if (cookies.length === 0) return undefined;
-        console.log(`[SCRAPE] Injected ${cookies.length} cookies from headful session`);
+        console.log(`[SCRAPE] Injected ${cookies.length} cookies from shared browser state`);
         return cookies.map(c => `${c.name}=${c.value}`).join('; ');
     } catch (e) {
-        if (e.code !== 'ENOENT') console.error('[SCRAPE] Failed to inject headful cookies:', e.message);
+        console.error('[SCRAPE] Failed to inject shared browser cookies:', e.message);
         return undefined;
     }
 }

--- a/src/agent/browser.js
+++ b/src/agent/browser.js
@@ -7,22 +7,20 @@ const { setupNavigationProtection } = require('../../url-utils');
 const { installMouseHelper } = require('./dom-utils');
 const { getInjectableScript } = require('idcac-playwright');
 const { installTurnstileInterceptor } = require('./figranite/captcha-interceptor');
+const { loadSharedBrowserState } = require('../../browser-storage-state');
 
 const PROFILE_DIR = path.join(__dirname, '../../data/browser-profile');
-const HEADFUL_STATE_PATH = path.join(__dirname, '../../data/headful-storage-state.json');
 
 async function injectHeadfulCookies(context) {
     try {
-        const raw = await fs.promises.readFile(HEADFUL_STATE_PATH, 'utf8');
-        const state = JSON.parse(raw);
-        const now = Date.now() / 1000;
-        const cookies = (state.cookies || []).filter(c => !c.expires || c.expires === -1 || c.expires > now);
+        const state = await loadSharedBrowserState();
+        const cookies = state?.cookies || [];
         if (cookies.length > 0) {
             await context.addCookies(cookies);
-            console.log(`Injected ${cookies.length} cookies from headful session`);
+            console.log(`Injected ${cookies.length} cookies from shared browser state`);
         }
     } catch (e) {
-        if (e.code !== 'ENOENT') console.error('Failed to inject headful cookies:', e.message);
+        console.error('Failed to inject shared browser cookies:', e.message);
     }
 }
 

--- a/src/agent/figranite/index.js
+++ b/src/agent/figranite/index.js
@@ -8,6 +8,7 @@ const { runExtractionScript } = require('../sandbox');
 const { cleanHtml } = require('../dom-utils');
 const { launchBrowser, createBrowserContext } = require('../browser');
 const cabinets = require('../../server/cabinets');
+const { saveSharedBrowserState } = require('../../../browser-storage-state');
 
 // New Modules
 const { buildBlockMap, randomBetween, getForeachItems } = require('./helpers');
@@ -207,12 +208,21 @@ async function runFigranite(data, options = {}) {
     let userStopped = false;
     let stopPageTranslation = () => {};
 
+    const syncBrowserState = async () => {
+        if (statelessExecution || isTestMode || !context) return;
+        // Agent contexts import the shared cookies after launch, but their persistent
+        // profile does not contain headful-only local storage for unrelated origins.
+        // Keep those origins intact while publishing the agent's updated cookies.
+        await saveSharedBrowserState(context, { preserveOrigins: true });
+    };
+
     const forceStop = async () => {
         isForceStopped = true;
         userStopped = true;
         stopRequested = true;
         logs.push('Execution force-stopped by user after 3s timeout.');
         try {
+            await syncBrowserState();
             if (page) await page.close().catch(() => {});
             if (context) await context.close().catch(() => {});
             if (browser) await browser.close().catch(() => {});
@@ -809,6 +819,7 @@ async function runFigranite(data, options = {}) {
 
         const video = page.video();
         if (!options.handoffContext) {
+            await syncBrowserState();
             try { await context.close(); } catch { }
         }
 
@@ -867,6 +878,7 @@ async function runFigranite(data, options = {}) {
         }
         error.executionLogs = logs;
         try {
+            await syncBrowserState();
             if (context) await context.close();
         } catch { }
         if (browser) await browser.close();

--- a/tests/headful-session-isolation.test.js
+++ b/tests/headful-session-isolation.test.js
@@ -1,0 +1,105 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const fs = require('fs');
+const Module = require('module');
+const path = require('path');
+
+const originalRequire = Module.prototype.require;
+let persistentLaunches = 0;
+let contextOptions = null;
+
+class FakePage extends EventEmitter {
+    isClosed() { return false; }
+    async goto() { }
+}
+
+class FakeContext extends EventEmitter {
+    constructor() {
+        super();
+        this.page = new FakePage();
+    }
+    pages() { return [this.page]; }
+    async addInitScript() { }
+    async exposeBinding() { }
+    async storageState() { return { cookies: [], origins: [] }; }
+    async newCDPSession() { throw new Error('CDP is not needed in this test'); }
+    async close() { this.emit('close'); }
+}
+
+class FakeBrowser extends EventEmitter {
+    async newContext(options) {
+        contextOptions = options;
+        return new FakeContext();
+    }
+    async close() { this.emit('disconnected'); }
+}
+
+Module.prototype.require = function (request) {
+    if (request === './stealth-chromium') {
+        return {
+            chromium: {
+                launch: async () => new FakeBrowser(),
+                launchPersistentContext: async () => {
+                    persistentLaunches++;
+                    throw new Error('Headful mode must not reuse a persistent profile');
+                }
+            }
+        };
+    }
+    if (request === './proxy-rotation') {
+        return { getProxySelection: () => ({ proxy: null }) };
+    }
+    if (request === './user-agent-settings') {
+        return { selectUserAgent: async () => 'Figranium Test Agent' };
+    }
+    if (request === './url-utils') {
+        return { validateUrl: async () => {}, setupNavigationProtection: async () => {} };
+    }
+    if (request === './src/agent/translate') {
+        return { installPageTranslation: async () => {} };
+    }
+    return originalRequire.apply(this, arguments);
+};
+
+(async () => {
+    const statePath = path.join(__dirname, '../data/headful-storage-state.json');
+    const stateDir = path.dirname(statePath);
+    const stateDirExisted = fs.existsSync(stateDir);
+    const previousState = fs.existsSync(statePath) ? fs.readFileSync(statePath) : null;
+
+    try {
+        fs.mkdirSync(stateDir, { recursive: true });
+        fs.writeFileSync(statePath, JSON.stringify({
+            cookies: [
+                { name: 'valid', value: 'yes', domain: 'example.com', path: '/', expires: -1 },
+                { name: 'expired', value: 'no', domain: 'example.com', path: '/', expires: 1 }
+            ],
+            origins: [{ origin: 'https://example.com', localStorage: [{ name: 'theme', value: 'dark' }] }]
+        }));
+
+        const { runHeadful } = require('../headful');
+        const response = {
+            json() {
+                setImmediate(() => require('../headful').getActiveSession().browser.emit('disconnected'));
+            }
+        };
+
+        await runHeadful({ url: 'https://example.com' }, { res: response });
+
+        assert.strictEqual(persistentLaunches, 0, 'headful sessions should not launch a persistent profile');
+        assert.ok(contextOptions, 'headful session should create an isolated browser context');
+        assert.deepStrictEqual(contextOptions.storageState.cookies.map(cookie => cookie.name), ['valid']);
+        assert.strictEqual(contextOptions.storageState.origins[0].origin, 'https://example.com');
+        console.log('Headful session isolation test passed.');
+    } finally {
+        Module.prototype.require = originalRequire;
+        if (previousState) fs.writeFileSync(statePath, previousState);
+        else if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
+        if (!stateDirExisted) {
+            try { fs.rmdirSync(stateDir); } catch { }
+        }
+    }
+})().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/tests/shared-browser-state.test.js
+++ b/tests/shared-browser-state.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const {
+    SHARED_BROWSER_STATE_PATH,
+    loadSharedBrowserState,
+    saveSharedBrowserState
+} = require('../browser-storage-state');
+
+const stateDir = path.dirname(SHARED_BROWSER_STATE_PATH);
+const stateDirExisted = fs.existsSync(stateDir);
+const previousState = fs.existsSync(SHARED_BROWSER_STATE_PATH)
+    ? fs.readFileSync(SHARED_BROWSER_STATE_PATH)
+    : null;
+
+const contextWithState = (state) => ({
+    storageState: async () => state
+});
+
+(async () => {
+    try {
+        await saveSharedBrowserState(contextWithState({
+            cookies: [{ name: 'headful', value: 'one', domain: 'example.com', path: '/', expires: -1 }],
+            origins: [{ origin: 'https://example.com', localStorage: [{ name: 'login', value: 'yes' }] }]
+        }));
+
+        await saveSharedBrowserState(contextWithState({
+            cookies: [
+                { name: 'headful', value: 'one', domain: 'example.com', path: '/', expires: -1 },
+                { name: 'headless', value: 'two', domain: 'example.com', path: '/', expires: -1 },
+                { name: 'expired', value: 'no', domain: 'example.com', path: '/', expires: 1 }
+            ],
+            origins: []
+        }), { preserveOrigins: true });
+
+        const sharedState = await loadSharedBrowserState();
+        assert.deepStrictEqual(sharedState.cookies.map(cookie => cookie.name), ['headful', 'headless']);
+        assert.strictEqual(sharedState.origins[0].origin, 'https://example.com');
+        console.log('Shared browser state test passed.');
+    } finally {
+        if (previousState) fs.writeFileSync(SHARED_BROWSER_STATE_PATH, previousState);
+        else if (fs.existsSync(SHARED_BROWSER_STATE_PATH)) fs.unlinkSync(SHARED_BROWSER_STATE_PATH);
+        if (!stateDirExisted) {
+            try { fs.rmdirSync(stateDir); } catch { }
+        }
+    }
+})().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- launch headful sessions in isolated browser contexts so persistent-profile session and service-worker state cannot revive unrelated authenticated tabs
- add a shared, atomic browser-state store so stateful headless and headful browser runs continue exchanging cookies in both directions
- preserve headful local storage and IndexedDB while headless runs publish updated cookies
- route HTTP scrape cookie loading through the same shared state
- include the shared state helper in the npm package

## Verification

- `node tests/shared-browser-state.test.js`
- `node tests/headful-session-isolation.test.js`
- `npm test`
- `npm run build`
- `npm pack --dry-run --json` (confirmed `browser-storage-state.js` is packaged)

A live Playwright browser run was not available in the workspace because the Chromium binary is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared browser state persistence across sessions, including cookies, local storage, and IndexedDB.
  * Preserves valid cookies while excluding expired ones.
  * Supports retaining existing browser origins during state updates.
  * Improved browser session isolation by using fresh contexts with shared state.

* **Bug Fixes**
  * Improved handling and logging of browser state loading and saving errors.
  * Added reliable state synchronization during normal completion, interruption, and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->